### PR TITLE
Add global VM suffix and Let's Encrypt SSL certificates

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -3,7 +3,7 @@
 
 provider "registry.terraform.io/hashicorp/http" {
   version     = "3.5.0"
-  constraints = ">= 3.4.0"
+  constraints = "~> 3.5"
   hashes = [
     "h1:dl73+8wzQR++HFGoJgDqY3mj3pm14HUuH/CekVyOj5s=",
     "zh:047c5b4920751b13425efe0d011b3a23a3be97d02d9c0e3c60985521c9c456b7",
@@ -18,6 +18,25 @@ provider "registry.terraform.io/hashicorp/http" {
     "zh:843feacacd86baed820f81a6c9f7bd32cf302db3d7a0f39e87976ebc7a7cc2ee",
     "zh:a9ea5096ab91aab260b22e4251c05f08dad2ed77e43e5e4fadcdfd87f2c78926",
     "zh:d02b288922811739059e90184c7f76d45d07d3a77cc48d0b15fd3db14e928623",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/null" {
+  version = "3.2.4"
+  hashes = [
+    "h1:L5V05xwp/Gto1leRryuesxjMfgZwjb7oool4WS1UEFQ=",
+    "zh:59f6b52ab4ff35739647f9509ee6d93d7c032985d9f8c6237d1f8a59471bbbe2",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:795c897119ff082133150121d39ff26cb5f89a730a2c8c26f3a9c1abf81a9c43",
+    "zh:7b9c7b16f118fbc2b05a983817b8ce2f86df125857966ad356353baf4bff5c0a",
+    "zh:85e33ab43e0e1726e5f97a874b8e24820b6565ff8076523cc2922ba671492991",
+    "zh:9d32ac3619cfc93eb3c4f423492a8e0f79db05fec58e449dee9b2d5873d5f69f",
+    "zh:9e15c3c9dd8e0d1e3731841d44c34571b6c97f5b95e8296a45318b94e5287a6e",
+    "zh:b4c2ab35d1b7696c30b64bf2c0f3a62329107bd1a9121ce70683dec58af19615",
+    "zh:c43723e8cc65bcdf5e0c92581dcbbdcbdcf18b8d2037406a5f2033b1e22de442",
+    "zh:ceb5495d9c31bfb299d246ab333f08c7fb0d67a4f82681fbf47f2a21c3e11ab5",
+    "zh:e171026b3659305c558d9804062762d168f50ba02b88b231d20ec99578a6233f",
+    "zh:ed0fe2acdb61330b01841fa790be00ec6beaac91d41f311fb8254f74eb6a711f",
   ]
 }
 
@@ -41,9 +60,29 @@ provider "registry.terraform.io/hashicorp/random" {
   ]
 }
 
+provider "registry.terraform.io/hashicorp/tls" {
+  version     = "4.1.0"
+  constraints = "~> 4.0"
+  hashes = [
+    "h1:zEv9tY1KR5vaLSyp2lkrucNJ+Vq3c+sTFK9GyQGLtFs=",
+    "zh:14c35d89307988c835a7f8e26f1b83ce771e5f9b41e407f86a644c0152089ac2",
+    "zh:2fb9fe7a8b5afdbd3e903acb6776ef1be3f2e587fb236a8c60f11a9fa165faa8",
+    "zh:35808142ef850c0c60dd93dc06b95c747720ed2c40c89031781165f0c2baa2fc",
+    "zh:35b5dc95bc75f0b3b9c5ce54d4d7600c1ebc96fbb8dfca174536e8bf103c8cdc",
+    "zh:38aa27c6a6c98f1712aa5cc30011884dc4b128b4073a4a27883374bfa3ec9fac",
+    "zh:51fb247e3a2e88f0047cb97bb9df7c228254a3b3021c5534e4563b4007e6f882",
+    "zh:62b981ce491e38d892ba6364d1d0cdaadcee37cc218590e07b310b1dfa34be2d",
+    "zh:bc8e47efc611924a79f947ce072a9ad698f311d4a60d0b4dfff6758c912b7298",
+    "zh:c149508bd131765d1bc085c75a870abb314ff5a6d7f5ac1035a8892d686b6297",
+    "zh:d38d40783503d278b63858978d40e07ac48123a2925e1a6b47e62179c046f87a",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:fb07f708e3316615f6d218cec198504984c0ce7000b9f1eebff7516e384f4b54",
+  ]
+}
+
 provider "registry.terraform.io/linode/linode" {
   version     = "3.8.0"
-  constraints = ">= 3.6.0, ~> 3.6"
+  constraints = ">= 2.0.0, >= 3.6.0, ~> 3.6"
   hashes = [
     "h1:pb9uLs4eNBkS1KBx2MALTJaKw+ujjEo0aKGhJvn1U1M=",
     "zh:233b3c2e15b0a2a7e609c85fd0b3595f3142fec655ba1d02b70898d382690777",
@@ -60,5 +99,26 @@ provider "registry.terraform.io/linode/linode" {
     "zh:ea2856e173d7717b1179b8191809f232e1eaa26f372260cc5e659a510a12ecd2",
     "zh:fbf4dfcd9219695904bbfd2bacbb8ac5c31327bc3fed43b07b7438213eb77046",
     "zh:ffa420dc87859daccd6a8d93e058cf32815fd78de25b241a15fd2b125c325acb",
+  ]
+}
+
+provider "registry.terraform.io/vancluever/acme" {
+  version     = "2.43.0"
+  constraints = "~> 2.21"
+  hashes = [
+    "h1:F3zIu5OAKD0XWb/Q3RRTANwaVpfypfsu1cfnjeFXbbo=",
+    "zh:03d1c70a9f9040688e6cb54de5f7fd063c549d3ada65bcc0cd7b5fae881dbed9",
+    "zh:29f7f801a9176ff59a7ac5f194539e85ad808e99ae2645238344b1c4432e32e3",
+    "zh:411c634a7db95bc7313720c9389b3418e3dfd3f4395b526857b48cf8d67a3834",
+    "zh:715e0478aa1c633e6ad6fcdcb8e686d3a68bb77b66d4f5d6e35afc61373f83a1",
+    "zh:773bb4672dbc992dc729203ef76e4112c769dd568c2135dbf0a38ff154e0eaea",
+    "zh:82715441beedce00be851564eb0751b59c781d9e426a9e529525a1439c3d1362",
+    "zh:8aa2854015f983ee67072e2f0931ab75d2140f6dea4c8310d9b828c8cbeeee1d",
+    "zh:936b53524e6639ced1e8945cec8ab7d8ece763900bdb41a9502bf5b0561910a5",
+    "zh:9f1e0575ec284233d1bbaadb1b0733f6f99324b502feb3d183d2181b6452e9d9",
+    "zh:db3b6de77d07c922bcb105b32d716e879cfe01f71647a58ec1267a9d940d7f92",
+    "zh:e4f97d2a5e57e2be42faf79041e733954a4ea719c90e152f275c3527e47b4364",
+    "zh:e956dd17d09743426f891916b4e70a013eaaa73303cda366544bf05a4e4f47be",
+    "zh:fa87ae7d963a121fade3f197723744a25edbb248bdd48b02c2ea8b9d98bb230d",
   ]
 }

--- a/main.tf
+++ b/main.tf
@@ -40,13 +40,12 @@ resource "acme_registration" "resilio" {
 
 # Let's Encrypt wildcard certificate for all Resilio instances
 resource "acme_certificate" "resilio" {
-  account_key_pem          = acme_registration.resilio.account_key_pem
-  common_name              = "${var.project_name}.${var.tld}"
-  subject_alternative_names = [
-    "*.${var.project_name}.${var.tld}",
-    # Add each region-specific subdomain
-    for region in var.regions : "${var.project_name}.${region}.${var.tld}"
-  ]
+  account_key_pem = acme_registration.resilio.account_key_pem
+  common_name     = "${var.project_name}.${var.tld}"
+  subject_alternative_names = concat(
+    ["*.${var.project_name}.${var.tld}"],
+    [for region in var.regions : "${var.project_name}.${region}.${var.tld}"]
+  )
 
   dns_challenge {
     provider = "linode"

--- a/main.tf
+++ b/main.tf
@@ -161,18 +161,18 @@ locals {
 
   # Backup configuration to pass to instances
   backup_config = {
-    enabled           = var.backup_enabled || var.object_storage_access_key != "CHANGEME"
-    mode              = var.backup_mode
-    schedule          = var.backup_schedule
-    transfers         = var.backup_transfers
-    bandwidth_limit   = var.backup_bandwidth_limit
-    versioning        = var.backup_versioning
-    retention_days    = var.backup_retention_days
-    access_key        = local.backup_access_key
-    secret_key        = local.backup_secret_key
-    primary_endpoint  = local.backup_primary_endpoint
-    primary_bucket    = local.backup_primary_bucket
-    all_buckets       = local.backup_buckets
+    enabled          = var.backup_enabled || var.object_storage_access_key != "CHANGEME"
+    mode             = var.backup_mode
+    schedule         = var.backup_schedule
+    transfers        = var.backup_transfers
+    bandwidth_limit  = var.backup_bandwidth_limit
+    versioning       = var.backup_versioning
+    retention_days   = var.backup_retention_days
+    access_key       = local.backup_access_key
+    secret_key       = local.backup_secret_key
+    primary_endpoint = local.backup_primary_endpoint
+    primary_bucket   = local.backup_primary_bucket
+    all_buckets      = local.backup_buckets
   }
 }
 
@@ -205,7 +205,7 @@ module "resilio_firewall" {
 
   project_name = var.project_name
   suffix       = random_id.global_suffix.hex # Use global suffix
-  tags         = local.tags # Concat tags and tld
+  tags         = local.tags                  # Concat tags and tld
 }
 
 # Create jumpbox instance (bastion host for secure access)
@@ -226,14 +226,14 @@ module "linode_instances" {
 
   for_each = toset(var.regions)
 
-  region                 = each.key          # "us-east"
-  instance_type          = var.instance_type # "g6-standard-2"
-  ssh_public_key         = var.ssh_public_key
-  project_name           = var.project_name # "resilio-sync"
-  suffix                 = random_id.global_suffix.hex # Use global suffix
+  region         = each.key          # "us-east"
+  instance_type  = var.instance_type # "g6-standard-2"
+  ssh_public_key = var.ssh_public_key
+  project_name   = var.project_name            # "resilio-sync"
+  suffix         = random_id.global_suffix.hex # Use global suffix
 
   # Per-folder volume configuration (new)
-  resilio_folders = var.resilio_folders       # Map of folder names to {key, size}
+  resilio_folders = var.resilio_folders                      # Map of folder names to {key, size}
   folder_volumes  = module.storage_volumes[each.key].volumes # Map of folder names to volume details
 
   # Deprecated - kept for backward compatibility

--- a/main.tf
+++ b/main.tf
@@ -88,15 +88,15 @@ resource "acme_certificate" "resilio" {
   dns_challenge {
     provider = "linode"
     config = {
-      LINODE_TOKEN = var.linode_token
+      LINODE_TOKEN               = var.linode_token
+      LINODE_PROPAGATION_TIMEOUT = "1200" # 20 minutes for DNS propagation
+      LINODE_POLLING_INTERVAL    = "30"   # Check every 30 seconds
+      LINODE_TTL                 = "300"  # 5 minute TTL (Linode minimum)
     }
   }
 
   # Renew when less than 30 days remain
   min_days_remaining = 30
-
-  # Certificate depends on DNS domain existing first (not the A/AAAA records)
-  depends_on = [linode_domain.resilio, data.linode_domain.existing]
 }
 
 # Create per-folder data volumes for each region

--- a/main.tf
+++ b/main.tf
@@ -56,6 +56,9 @@ resource "acme_certificate" "resilio" {
 
   # Renew when less than 30 days remain
   min_days_remaining = 30
+
+  # Certificate depends on DNS domain existing first
+  depends_on = [module.dns]
 }
 
 # Create per-folder data volumes for each region

--- a/modules/dns/main.tf
+++ b/modules/dns/main.tf
@@ -1,30 +1,11 @@
 # modules/dns/main.tf
-
-# Create new domain (if create_domain = true)
-resource "linode_domain" "resilio" {
-  count = var.create_domain ? 1 : 0
-
-  type      = "master"
-  domain    = var.tld
-  soa_email = "admin@${var.tld}"
-  tags      = ["terraform", "dns", var.project_name]
-
-  lifecycle {
-    prevent_destroy = true
-  }
-}
-
-# Use existing domain (if create_domain = false)
-data "linode_domain" "existing" {
-  count = var.create_domain ? 0 : 1
-
-  domain = var.tld
-}
+# This module creates DNS A/AAAA records for Resilio instances
+# The domain itself is created/managed in main.tf to avoid circular dependencies with ACME
 
 # DNS A records - keyed by region (static, known at plan time)
 resource "linode_domain_record" "resilio_A" {
   for_each    = var.dns_records
-  domain_id   = var.create_domain ? linode_domain.resilio[0].id : data.linode_domain.existing[0].id
+  domain_id   = var.domain_id
   record_type = "A"
   name        = "${var.project_name}.${each.key}" # e.g., "resilio-sync.us-east"
   target      = each.value.ipv4
@@ -34,7 +15,7 @@ resource "linode_domain_record" "resilio_A" {
 # DNS AAAA records - keyed by region (static, known at plan time)
 resource "linode_domain_record" "resilio_AAAA" {
   for_each    = var.dns_records
-  domain_id   = var.create_domain ? linode_domain.resilio[0].id : data.linode_domain.existing[0].id
+  domain_id   = var.domain_id
   record_type = "AAAA"
   name        = "${var.project_name}.${each.key}" # e.g., "resilio-sync.us-east"
   target      = replace(each.value.ipv6, "/128", "")

--- a/modules/dns/outputs.tf
+++ b/modules/dns/outputs.tf
@@ -1,25 +1,5 @@
 # modules/dns/outputs.tf
-
-output "domain_id" {
-  description = "ID of the domain (created or existing)"
-  value       = var.create_domain ? linode_domain.resilio[0].id : data.linode_domain.existing[0].id
-}
-
-output "nameservers" {
-  description = "Nameservers for the domain (configure these at your domain registrar)"
-  value = [
-    "ns1.linode.com",
-    "ns2.linode.com",
-    "ns3.linode.com",
-    "ns4.linode.com",
-    "ns5.linode.com"
-  ]
-}
-
-output "domain_name" {
-  description = "The domain name"
-  value       = var.tld
-}
+# Domain-related outputs are now in main.tf where the domain is created
 
 output "dns_records" {
   description = "Map of DNS A records created"

--- a/modules/dns/variables.tf
+++ b/modules/dns/variables.tf
@@ -1,14 +1,8 @@
 # modules/dns/variables.tf
 
-variable "tld" {
-  description = "Top-Level Domain (TLD)"
-  type        = string
-}
-
-variable "create_domain" {
-  description = "Whether to create the domain or use an existing one. Set to false if domain already exists in Linode DNS."
-  type        = bool
-  default     = true
+variable "domain_id" {
+  description = "Linode domain ID for creating DNS records"
+  type        = number
 }
 
 variable "dns_records" {
@@ -28,10 +22,4 @@ variable "ttl_sec" {
   description = "TTL in seconds"
   type        = number
   default     = 60
-}
-
-variable "tags" {
-  description = "Set of tags to apply to all resources"
-  type        = list(string)
-  default     = ["deployment: terraform", "app: resilio"]
 }

--- a/modules/jumpbox-firewall/main.tf
+++ b/modules/jumpbox-firewall/main.tf
@@ -1,18 +1,8 @@
 # modules/jumpbox-firewall/main.tf
 
-# Generate a unique identifier for this firewall
-resource "random_id" "jumpbox_firewall" {
-  byte_length = 2
-
-  keepers = {
-    # Regenerate if project name changes
-    project_name = var.project_name
-  }
-}
-
-# Create a Linode firewall for the jumpbox
+# Create a Linode firewall for the jumpbox (uses global suffix for consistency)
 resource "linode_firewall" "jumpbox" {
-  label           = "${var.project_name}-jumpbox-fw-${random_id.jumpbox_firewall.hex}"
+  label           = "${var.project_name}-jumpbox-fw-${var.suffix}"
   inbound_policy  = "DROP"
   outbound_policy = "ACCEPT"
 

--- a/modules/jumpbox-firewall/variables.tf
+++ b/modules/jumpbox-firewall/variables.tf
@@ -5,6 +5,11 @@ variable "project_name" {
   type        = string
 }
 
+variable "suffix" {
+  description = "Global suffix shared across all resources (from random_id.global_suffix)"
+  type        = string
+}
+
 variable "tags" {
   description = "Set of tags to apply to all resources"
   type        = list(string)

--- a/modules/jumpbox/main.tf
+++ b/modules/jumpbox/main.tf
@@ -1,23 +1,14 @@
 # modules/jumpbox/main.tf
 
-# Generate a unique identifier for this instance
-resource "random_id" "jumpbox" {
-  byte_length = 2
-
-  keepers = {
-    project_name = var.project_name
-  }
-}
-
 # Random password for root account (required by Linode API)
 resource "random_password" "root" {
   length  = 32
   special = true
 }
 
-# Jumpbox Linode instance
+# Jumpbox Linode instance (uses global suffix for consistency)
 resource "linode_instance" "jumpbox" {
-  label     = "${var.project_name}-jumpbox-${random_id.jumpbox.hex}"
+  label     = "${var.project_name}-jumpbox-${var.suffix}"
   region    = var.region
   type      = var.instance_type
   image     = "linode/ubuntu24.04"

--- a/modules/jumpbox/variables.tf
+++ b/modules/jumpbox/variables.tf
@@ -20,6 +20,11 @@ variable "project_name" {
   type        = string
 }
 
+variable "suffix" {
+  description = "Global suffix shared across all VMs (from random_id.global_suffix)"
+  type        = string
+}
+
 variable "firewall_id" {
   description = "ID of the firewall to attach to the jumpbox"
   type        = string

--- a/modules/linode/cloud-init.tpl
+++ b/modules/linode/cloud-init.tpl
@@ -317,7 +317,7 @@ write_files:
         regenerate|apply)
           [ -f "$FOLDERS_FILE" ] || exit 1
           FOLDERS=$(cat "$FOLDERS_FILE")
-          sed "s|FOLDERS_PLACEHOLDER|$FOLDERS|" "$CONFIG_TPL" > "$CONFIG"
+          sed "s|FOLDERS_PLACEHOLDER|$FOLDERS|" "$CONFIG_TPL" | jq . > "$CONFIG"
           chown rslsync:rslsync "$CONFIG"
           [ "$1" = "apply" ] && systemctl restart resilio-sync
           ;;
@@ -576,9 +576,9 @@ runcmd:
       done
     fi
 
-    # Generate config.json from template + volume-based folders
+    # Generate config.json from template + volume-based folders (formatted with jq)
     FOLDERS=$(cat "$FOLDERS_FILE")
-    sed "s|FOLDERS_PLACEHOLDER|$FOLDERS|" /etc/resilio-sync/config.json.tpl > /etc/resilio-sync/config.json
+    sed "s|FOLDERS_PLACEHOLDER|$FOLDERS|" /etc/resilio-sync/config.json.tpl | jq . > /etc/resilio-sync/config.json
     chown rslsync:rslsync /etc/resilio-sync/config.json
     echo ">>> Resilio config generated"
 

--- a/modules/linode/main.tf
+++ b/modules/linode/main.tf
@@ -1,19 +1,8 @@
 # modules/linode/main.tf
 
-# Generate a unique identifier for this instance
-resource "random_id" "instance" {
-  byte_length = 4
-
-  keepers = {
-    # Regenerate if project name or region changes
-    project_name = var.project_name
-    region       = var.region
-  }
-}
-
 locals {
-  # Label format: resilio-sync-us-east-a1b2c3d4
-  label = "${var.project_name}-${var.region}-${random_id.instance.hex}"
+  # Label format: resilio-sync-us-east-a1b2c3d4 (uses global suffix)
+  label = "${var.project_name}-${var.region}-${var.suffix}"
 
   # Extract non-sensitive folder names for iteration
   # The keys (secrets) are sensitive, but folder names are not
@@ -98,6 +87,10 @@ resource "linode_instance" "resilio" {
       object_storage_endpoint   = var.object_storage_endpoint
       object_storage_bucket     = var.object_storage_bucket
       enable_backup             = var.enable_backup
+      # SSL certificate for HTTPS
+      ssl_certificate     = var.ssl_certificate
+      ssl_private_key     = var.ssl_private_key
+      ssl_issuer_cert     = var.ssl_issuer_cert
     }))
   }
 

--- a/modules/linode/main.tf
+++ b/modules/linode/main.tf
@@ -82,15 +82,31 @@ resource "linode_instance" "resilio" {
       tld                    = var.tld
       ubuntu_advantage_token = var.ubuntu_advantage_token
       base_mount_point       = "/mnt/resilio-data"
+      # Legacy backup variables (for backward compatibility)
       object_storage_access_key = var.object_storage_access_key
       object_storage_secret_key = var.object_storage_secret_key
       object_storage_endpoint   = var.object_storage_endpoint
       object_storage_bucket     = var.object_storage_bucket
       enable_backup             = var.enable_backup
+      # New backup configuration
+      backup_config_json = jsonencode({
+        enabled          = var.backup_config.enabled
+        mode             = var.backup_config.mode
+        schedule         = var.backup_config.schedule
+        transfers        = var.backup_config.transfers
+        bandwidth_limit  = var.backup_config.bandwidth_limit
+        versioning       = var.backup_config.versioning
+        retention_days   = var.backup_config.retention_days
+        primary_endpoint = var.backup_config.primary_endpoint
+        primary_bucket   = var.backup_config.primary_bucket
+        all_buckets      = var.backup_config.all_buckets
+      })
+      backup_access_key = var.backup_config.access_key
+      backup_secret_key = var.backup_config.secret_key
       # SSL certificate for HTTPS
-      ssl_certificate     = var.ssl_certificate
-      ssl_private_key     = var.ssl_private_key
-      ssl_issuer_cert     = var.ssl_issuer_cert
+      ssl_certificate = var.ssl_certificate
+      ssl_private_key = var.ssl_private_key
+      ssl_issuer_cert = var.ssl_issuer_cert
     }))
   }
 

--- a/modules/linode/variables.tf
+++ b/modules/linode/variables.tf
@@ -136,7 +136,7 @@ variable "backup_config" {
     secret_key       = string
     primary_endpoint = string
     primary_bucket   = string
-    all_buckets      = map(object({
+    all_buckets = map(object({
       name     = string
       cluster  = string
       endpoint = string
@@ -177,4 +177,24 @@ variable "ssl_issuer_cert" {
   description = "SSL issuer/CA certificate (PEM format)"
   type        = string
   sensitive   = true
+}
+
+# Variables for file provisioner (script transfer)
+variable "ssh_private_key" {
+  description = "SSH private key for file provisioner to connect to instance"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "jumpbox_ip" {
+  description = "Jumpbox IP address for bastion host connection"
+  type        = string
+  default     = ""
+}
+
+variable "provision_scripts" {
+  description = "Whether to use file provisioner to transfer scripts (requires ssh_private_key and jumpbox_ip)"
+  type        = bool
+  default     = false
 }

--- a/modules/linode/variables.tf
+++ b/modules/linode/variables.tf
@@ -19,6 +19,11 @@ variable "project_name" {
   type        = string
 }
 
+variable "suffix" {
+  description = "Global suffix shared across all VMs (from random_id.global_suffix)"
+  type        = string
+}
+
 # New per-folder volume configuration
 variable "resilio_folders" {
   description = "Map of folder names to their configurations"
@@ -114,4 +119,23 @@ variable "enable_backup" {
   description = "Whether to enable Object Storage backups on this instance"
   type        = bool
   default     = false
+}
+
+# SSL certificate variables for Resilio HTTPS
+variable "ssl_certificate" {
+  description = "Let's Encrypt SSL certificate (PEM format)"
+  type        = string
+  sensitive   = true
+}
+
+variable "ssl_private_key" {
+  description = "SSL certificate private key (PEM format)"
+  type        = string
+  sensitive   = true
+}
+
+variable "ssl_issuer_cert" {
+  description = "SSL issuer/CA certificate (PEM format)"
+  type        = string
+  sensitive   = true
 }

--- a/modules/linode/variables.tf
+++ b/modules/linode/variables.tf
@@ -116,9 +116,48 @@ variable "object_storage_bucket" {
 }
 
 variable "enable_backup" {
-  description = "Whether to enable Object Storage backups on this instance"
+  description = "[LEGACY] Whether to enable Object Storage backups on this instance"
   type        = bool
   default     = false
+}
+
+# New backup configuration object
+variable "backup_config" {
+  description = "Backup configuration object with all backup settings"
+  type = object({
+    enabled          = bool
+    mode             = string # "scheduled", "realtime", or "hybrid"
+    schedule         = string # Cron schedule
+    transfers        = number # Parallel transfers
+    bandwidth_limit  = string # e.g., "10M" or ""
+    versioning       = bool
+    retention_days   = number
+    access_key       = string
+    secret_key       = string
+    primary_endpoint = string
+    primary_bucket   = string
+    all_buckets      = map(object({
+      name     = string
+      cluster  = string
+      endpoint = string
+      hostname = string
+    }))
+  })
+  sensitive = true
+  default = {
+    enabled          = false
+    mode             = "scheduled"
+    schedule         = "0 2 * * *"
+    transfers        = 8
+    bandwidth_limit  = ""
+    versioning       = true
+    retention_days   = 90
+    access_key       = ""
+    secret_key       = ""
+    primary_endpoint = ""
+    primary_bucket   = ""
+    all_buckets      = {}
+  }
 }
 
 # SSL certificate variables for Resilio HTTPS

--- a/modules/object-storage/main.tf
+++ b/modules/object-storage/main.tf
@@ -19,17 +19,13 @@ resource "linode_object_storage_bucket" "backup" {
   }
 }
 
-# Object Storage access key - one per bucket to avoid dynamic block provider bug
+# Object Storage access key (unlimited access)
+# TODO: Add bucket_access block when Linode provider bug is fixed
+# Bug: bucket_access causes "Provider produced inconsistent final plan" error
+# The provider sets cluster=UnknownVal internally even when only region is specified
+# Report at: https://github.com/linode/terraform-provider-linode/issues
 resource "linode_object_storage_key" "backup" {
-  for_each = linode_object_storage_bucket.backup
-
-  label = "${var.project_name}-backup-key-${each.key}-${var.suffix}"
-
-  bucket_access {
-    bucket_name = each.value.label
-    region      = each.value.region
-    permissions = "read_write"
-  }
+  label = "${var.project_name}-backup-key-${var.suffix}"
 }
 
 # Lifecycle policy for backup retention

--- a/modules/object-storage/main.tf
+++ b/modules/object-storage/main.tf
@@ -42,11 +42,12 @@ resource "linode_object_storage_key" "backup" {
 # Local values for bucket endpoints
 locals {
   # Map of region to bucket details
+  # Object Storage region IDs already include the suffix (e.g., us-east-1)
   bucket_details = {
     for region, bucket in linode_object_storage_bucket.backup : region => {
       name     = bucket.label
-      cluster  = "${bucket.region}-1" # For endpoint compatibility
-      endpoint = "${bucket.region}-1.linodeobjects.com"
+      cluster  = bucket.region # Region ID is already in correct format (e.g., us-east-1)
+      endpoint = "${bucket.region}.linodeobjects.com"
       hostname = bucket.hostname
     }
   }

--- a/modules/object-storage/main.tf
+++ b/modules/object-storage/main.tf
@@ -1,0 +1,58 @@
+# modules/object-storage/main.tf
+# Manages Linode Object Storage for Resilio Sync backups
+
+# Object Storage bucket for backups
+# One bucket per backup region for redundancy and performance
+resource "linode_object_storage_bucket" "backup" {
+  for_each = toset(var.backup_regions)
+
+  cluster    = "${each.key}-1" # e.g., "us-east-1", "eu-west-1"
+  label      = "${var.bucket_prefix}-${each.key}"
+  acl        = "private"
+  versioning = var.enable_versioning
+
+  # CORS configuration for potential web access
+  cors_enabled = false
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+# Object Storage access key with limited scope
+# This key only has access to the backup buckets
+resource "linode_object_storage_key" "backup" {
+  label = "${var.project_name}-backup-key-${var.suffix}"
+
+  # Grant read/write access to all backup buckets
+  dynamic "bucket_access" {
+    for_each = linode_object_storage_bucket.backup
+    content {
+      cluster     = bucket_access.value.cluster
+      bucket_name = bucket_access.value.label
+      permissions = "read_write"
+    }
+  }
+}
+
+# Lifecycle policy for backup retention
+# Applied via rclone configuration since Linode doesn't have native lifecycle rules
+# This is handled in the backup script with --max-age flags
+
+# Local values for bucket endpoints
+locals {
+  # Map of region to bucket details
+  bucket_details = {
+    for region, bucket in linode_object_storage_bucket.backup : region => {
+      name     = bucket.label
+      cluster  = bucket.cluster
+      endpoint = "${bucket.cluster}.linodeobjects.com"
+      hostname = bucket.hostname
+    }
+  }
+
+  # Primary bucket (first in alphabetical order for consistency)
+  primary_region   = sort(var.backup_regions)[0]
+  primary_bucket   = local.bucket_details[local.primary_region]
+  primary_endpoint = local.primary_bucket.endpoint
+}

--- a/modules/object-storage/main.tf
+++ b/modules/object-storage/main.tf
@@ -6,7 +6,7 @@
 resource "linode_object_storage_bucket" "backup" {
   for_each = toset(var.backup_regions)
 
-  cluster    = "${each.key}-1" # e.g., "us-east-1", "eu-west-1"
+  region     = each.key # e.g., "us-east", "eu-west"
   label      = "${var.bucket_prefix}-${each.key}"
   acl        = "private"
   versioning = var.enable_versioning
@@ -28,7 +28,7 @@ resource "linode_object_storage_key" "backup" {
   dynamic "bucket_access" {
     for_each = linode_object_storage_bucket.backup
     content {
-      cluster     = bucket_access.value.cluster
+      region      = bucket_access.value.region
       bucket_name = bucket_access.value.label
       permissions = "read_write"
     }
@@ -45,8 +45,8 @@ locals {
   bucket_details = {
     for region, bucket in linode_object_storage_bucket.backup : region => {
       name     = bucket.label
-      cluster  = bucket.cluster
-      endpoint = "${bucket.cluster}.linodeobjects.com"
+      cluster  = "${bucket.region}-1" # For endpoint compatibility
+      endpoint = "${bucket.region}-1.linodeobjects.com"
       hostname = bucket.hostname
     }
   }

--- a/modules/object-storage/outputs.tf
+++ b/modules/object-storage/outputs.tf
@@ -1,15 +1,33 @@
 # modules/object-storage/outputs.tf
 
+# Primary key (for backward compatibility - uses first region alphabetically)
 output "access_key" {
-  description = "Object Storage access key ID"
-  value       = linode_object_storage_key.backup.access_key
+  description = "Primary Object Storage access key ID (first region)"
+  value       = linode_object_storage_key.backup[local.primary_region].access_key
   sensitive   = true
 }
 
 output "secret_key" {
-  description = "Object Storage secret access key"
-  value       = linode_object_storage_key.backup.secret_key
+  description = "Primary Object Storage secret key (first region)"
+  value       = linode_object_storage_key.backup[local.primary_region].secret_key
   sensitive   = true
+}
+
+# All keys by region
+output "access_keys" {
+  description = "Map of Object Storage access keys by region"
+  value = {
+    for region, key in linode_object_storage_key.backup : region => key.access_key
+  }
+  sensitive = true
+}
+
+output "secret_keys" {
+  description = "Map of Object Storage secret keys by region"
+  value = {
+    for region, key in linode_object_storage_key.backup : region => key.secret_key
+  }
+  sensitive = true
 }
 
 output "buckets" {
@@ -32,9 +50,11 @@ output "bucket_names" {
   value       = [for bucket in linode_object_storage_bucket.backup : bucket.label]
 }
 
-output "key_id" {
-  description = "Object Storage key ID (for management)"
-  value       = linode_object_storage_key.backup.id
+output "key_ids" {
+  description = "Map of Object Storage key IDs by region"
+  value = {
+    for region, key in linode_object_storage_key.backup : region => key.id
+  }
 }
 
 output "rclone_remotes" {

--- a/modules/object-storage/outputs.tf
+++ b/modules/object-storage/outputs.tf
@@ -1,0 +1,54 @@
+# modules/object-storage/outputs.tf
+
+output "access_key" {
+  description = "Object Storage access key ID"
+  value       = linode_object_storage_key.backup.access_key
+  sensitive   = true
+}
+
+output "secret_key" {
+  description = "Object Storage secret access key"
+  value       = linode_object_storage_key.backup.secret_key
+  sensitive   = true
+}
+
+output "buckets" {
+  description = "Map of backup buckets by region"
+  value       = local.bucket_details
+}
+
+output "primary_bucket" {
+  description = "Primary backup bucket details (first region alphabetically)"
+  value       = local.primary_bucket
+}
+
+output "primary_endpoint" {
+  description = "Primary Object Storage endpoint URL"
+  value       = local.primary_endpoint
+}
+
+output "bucket_names" {
+  description = "List of all backup bucket names"
+  value       = [for bucket in linode_object_storage_bucket.backup : bucket.label]
+}
+
+output "key_id" {
+  description = "Object Storage key ID (for management)"
+  value       = linode_object_storage_key.backup.id
+}
+
+output "rclone_remotes" {
+  description = "Map of rclone remote configurations by region"
+  value = {
+    for region, details in local.bucket_details : region => {
+      remote_name = "backup-${region}"
+      endpoint    = details.endpoint
+      bucket      = details.name
+    }
+  }
+}
+
+output "versioning_enabled" {
+  description = "Whether versioning is enabled on backup buckets"
+  value       = var.enable_versioning
+}

--- a/modules/object-storage/outputs.tf
+++ b/modules/object-storage/outputs.tf
@@ -1,33 +1,15 @@
 # modules/object-storage/outputs.tf
 
-# Primary key (for backward compatibility - uses first region alphabetically)
 output "access_key" {
-  description = "Primary Object Storage access key ID (first region)"
-  value       = linode_object_storage_key.backup[local.primary_region].access_key
+  description = "Object Storage access key ID"
+  value       = linode_object_storage_key.backup.access_key
   sensitive   = true
 }
 
 output "secret_key" {
-  description = "Primary Object Storage secret key (first region)"
-  value       = linode_object_storage_key.backup[local.primary_region].secret_key
+  description = "Object Storage secret key"
+  value       = linode_object_storage_key.backup.secret_key
   sensitive   = true
-}
-
-# All keys by region
-output "access_keys" {
-  description = "Map of Object Storage access keys by region"
-  value = {
-    for region, key in linode_object_storage_key.backup : region => key.access_key
-  }
-  sensitive = true
-}
-
-output "secret_keys" {
-  description = "Map of Object Storage secret keys by region"
-  value = {
-    for region, key in linode_object_storage_key.backup : region => key.secret_key
-  }
-  sensitive = true
 }
 
 output "buckets" {
@@ -50,11 +32,9 @@ output "bucket_names" {
   value       = [for bucket in linode_object_storage_bucket.backup : bucket.label]
 }
 
-output "key_ids" {
-  description = "Map of Object Storage key IDs by region"
-  value = {
-    for region, key in linode_object_storage_key.backup : region => key.id
-  }
+output "key_id" {
+  description = "Object Storage key ID"
+  value       = linode_object_storage_key.backup.id
 }
 
 output "rclone_remotes" {

--- a/modules/object-storage/variables.tf
+++ b/modules/object-storage/variables.tf
@@ -1,0 +1,55 @@
+# modules/object-storage/variables.tf
+
+variable "project_name" {
+  description = "Project name for resource naming"
+  type        = string
+}
+
+variable "suffix" {
+  description = "Global suffix for resource naming"
+  type        = string
+}
+
+variable "bucket_prefix" {
+  description = "Prefix for bucket names (will be suffixed with region)"
+  type        = string
+  default     = "resilio-backup"
+
+  validation {
+    condition     = can(regex("^[a-z0-9][a-z0-9-]*[a-z0-9]$", var.bucket_prefix))
+    error_message = "Bucket prefix must be lowercase alphanumeric with hyphens, no leading/trailing hyphens."
+  }
+}
+
+variable "backup_regions" {
+  description = "List of Linode regions for backup storage (e.g., ['us-east', 'eu-west'])"
+  type        = list(string)
+
+  validation {
+    condition     = length(var.backup_regions) > 0
+    error_message = "At least one backup region must be specified."
+  }
+}
+
+variable "enable_versioning" {
+  description = "Enable object versioning for backup buckets (recommended for data protection)"
+  type        = bool
+  default     = true
+}
+
+variable "retention_days" {
+  description = "Number of days to retain backup versions (0 = keep forever)"
+  type        = number
+  default     = 90
+
+  validation {
+    condition     = var.retention_days >= 0
+    error_message = "Retention days must be 0 or greater."
+  }
+}
+
+variable "tags" {
+  description = "Tags to apply to resources"
+  type        = list(string)
+  default     = []
+}

--- a/modules/object-storage/versions.tf
+++ b/modules/object-storage/versions.tf
@@ -1,0 +1,11 @@
+# modules/object-storage/versions.tf
+
+terraform {
+  required_providers {
+    linode = {
+      source  = "linode/linode"
+      version = ">= 2.0"
+    }
+  }
+  required_version = ">= 1.5.0"
+}

--- a/modules/resilio-firewall/main.tf
+++ b/modules/resilio-firewall/main.tf
@@ -1,18 +1,8 @@
 # modules/resilio-firewall/main.tf
 
-# Generate a unique identifier for this firewall
-resource "random_id" "resilio_firewall" {
-  byte_length = 2
-
-  keepers = {
-    # Regenerate if project name changes
-    project_name = var.project_name
-  }
-}
-
-# Create a Linode firewall for resilio instances
+# Create a Linode firewall for resilio instances (uses global suffix for consistency)
 resource "linode_firewall" "resilio" {
-  label           = "${var.project_name}-resilio-fw-${random_id.resilio_firewall.hex}"
+  label           = "${var.project_name}-resilio-fw-${var.suffix}"
   inbound_policy  = "DROP"
   outbound_policy = "ACCEPT"
 

--- a/modules/resilio-firewall/variables.tf
+++ b/modules/resilio-firewall/variables.tf
@@ -17,6 +17,11 @@ variable "project_name" {
   type        = string
 }
 
+variable "suffix" {
+  description = "Global suffix shared across all resources (from random_id.global_suffix)"
+  type        = string
+}
+
 variable "tags" {
   description = "Set of tags to apply to all resources"
   type        = list(string)

--- a/modules/volume/main.tf
+++ b/modules/volume/main.tf
@@ -14,7 +14,7 @@ resource "linode_volume" "storage" {
 
   # Shortened label to fit 32 char limit: rs-{folder}-{region_prefix}
   # Example: rs-documents-us-eas (19 chars)
-  label = "rs-${each.key}-${substr(var.region, 0, 6)}"
+  label  = "rs-${each.key}-${substr(var.region, 0, 6)}"
   region = var.region
   size   = each.value
   tags = concat(

--- a/outputs.tf
+++ b/outputs.tf
@@ -74,3 +74,18 @@ output "firewall_configuration" {
   description = "Firewall configuration status"
   value       = "✅ Two separate firewalls configured: jumpbox-firewall (static rules) and resilio-firewall (auto-updated via Linode API)"
 }
+
+output "global_suffix" {
+  description = "Global suffix shared across all VMs and resources (useful for identifying related resources)"
+  value       = random_id.global_suffix.hex
+}
+
+output "ssl_certificate_domains" {
+  description = "Domains covered by the SSL certificate"
+  value       = acme_certificate.resilio.certificate_domain
+}
+
+output "ssl_certificate_expiry" {
+  description = "SSL certificate expiry date"
+  value       = acme_certificate.resilio.certificate_not_after
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -120,4 +120,5 @@ output "backup_source_regions" {
 output "backup_rehydrate_command" {
   description = "Command to restore from backup on a new VM"
   value       = var.backup_enabled || var.object_storage_access_key != "CHANGEME" ? "sudo /usr/local/bin/resilio-rehydrate.sh --list" : "Backups not configured"
+  sensitive   = true
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -39,13 +39,19 @@ output "resilio_firewall_id" {
 }
 
 output "domain_id" {
-  description = "ID of the created DNS domain"
-  value       = module.dns.domain_id
+  description = "ID of the DNS domain (created or existing)"
+  value       = local.domain_id
 }
 
 output "dns_nameservers" {
   description = "Nameservers for the DNS domain (configure these at your domain registrar)"
-  value       = module.dns.nameservers
+  value = [
+    "ns1.linode.com",
+    "ns2.linode.com",
+    "ns3.linode.com",
+    "ns4.linode.com",
+    "ns5.linode.com"
+  ]
 }
 
 output "ssh_connection_strings" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -89,3 +89,29 @@ output "ssl_certificate_expiry" {
   description = "SSL certificate expiry date"
   value       = acme_certificate.resilio.certificate_not_after
 }
+
+# Backup outputs
+output "backup_enabled" {
+  description = "Whether Terraform-managed backups are enabled"
+  value       = var.backup_enabled
+}
+
+output "backup_buckets" {
+  description = "Backup storage buckets by region (only when backup_enabled=true)"
+  value       = var.backup_enabled && length(module.backup_storage) > 0 ? module.backup_storage[0].buckets : {}
+}
+
+output "backup_mode" {
+  description = "Backup scheduling mode (scheduled, realtime, or hybrid)"
+  value       = var.backup_mode
+}
+
+output "backup_source_regions" {
+  description = "Regions that will run backups to Object Storage"
+  value       = local.effective_backup_source_regions
+}
+
+output "backup_rehydrate_command" {
+  description = "Command to restore from backup on a new VM"
+  value       = var.backup_enabled || var.object_storage_access_key != "CHANGEME" ? "sudo /usr/local/bin/resilio-rehydrate.sh --list" : "Backups not configured"
+}

--- a/provider.tf
+++ b/provider.tf
@@ -44,10 +44,25 @@ terraform {
       source  = "hashicorp/http"
       version = "~> 3.5"
     }
+    tls = {
+      source  = "hashicorp/tls"
+      version = "~> 4.0"
+    }
+    acme = {
+      source  = "vancluever/acme"
+      version = "~> 2.21"
+    }
   }
   required_version = ">= 1.5.0"
 }
 
 provider "linode" {
   token = var.linode_token
+}
+
+# ACME provider for Let's Encrypt certificates
+# Using Let's Encrypt production server (use staging for testing)
+provider "acme" {
+  server_url = "https://acme-v02.api.letsencrypt.org/directory"
+  # For testing, use: "https://acme-staging-v02.api.letsencrypt.org/directory"
 }

--- a/provider.tf
+++ b/provider.tf
@@ -61,8 +61,7 @@ provider "linode" {
 }
 
 # ACME provider for Let's Encrypt certificates
-# Using Let's Encrypt production server (use staging for testing)
+# Default: production. Set var.acme_server_url to staging for testing.
 provider "acme" {
-  server_url = "https://acme-v02.api.letsencrypt.org/directory"
-  # For testing, use: "https://acme-staging-v02.api.letsencrypt.org/directory"
+  server_url = var.acme_server_url
 }

--- a/provider.tf
+++ b/provider.tf
@@ -57,7 +57,8 @@ terraform {
 }
 
 provider "linode" {
-  token = var.linode_token
+  token             = var.linode_token
+  obj_use_temp_keys = true # Generate temporary keys for Object Storage operations
 }
 
 # ACME provider for Let's Encrypt certificates

--- a/scripts/cloud-init/collect-diagnostics.sh
+++ b/scripts/cloud-init/collect-diagnostics.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+# Collect all diagnostic logs for troubleshooting cloud-init and system issues
+set -e
+
+DIAG_DIR="/tmp/diagnostics-$(date +%Y%m%d-%H%M%S)"
+DIAG_TAR="$DIAG_DIR.tar.gz"
+
+echo "=== Collecting diagnostics to $DIAG_DIR ==="
+mkdir -p "$DIAG_DIR"
+
+# Cloud-init logs
+echo "Collecting cloud-init logs..."
+cp /var/log/cloud-init.log "$DIAG_DIR/" 2>/dev/null || true
+cp /var/log/cloud-init-output.log "$DIAG_DIR/" 2>/dev/null || true
+cloud-init status --long > "$DIAG_DIR/cloud-init-status.txt" 2>&1 || true
+cloud-init analyze show > "$DIAG_DIR/cloud-init-analyze.txt" 2>&1 || true
+cloud-init analyze blame > "$DIAG_DIR/cloud-init-blame.txt" 2>&1 || true
+
+# System logs
+echo "Collecting system logs..."
+journalctl -b --no-pager > "$DIAG_DIR/journalctl-boot.log" 2>&1 || true
+journalctl -u cloud-init --no-pager > "$DIAG_DIR/journalctl-cloud-init.log" 2>&1 || true
+journalctl -u cloud-final --no-pager > "$DIAG_DIR/journalctl-cloud-final.log" 2>&1 || true
+dmesg > "$DIAG_DIR/dmesg.log" 2>&1 || true
+
+# Custom application logs
+echo "Collecting application logs..."
+cp /var/log/volume-expand.log "$DIAG_DIR/" 2>/dev/null || true
+cp /var/log/resilio-backup.log "$DIAG_DIR/" 2>/dev/null || true
+journalctl -u resilio-sync --no-pager > "$DIAG_DIR/journalctl-resilio-sync.log" 2>&1 || true
+journalctl -u volume-auto-expand --no-pager > "$DIAG_DIR/journalctl-volume-expand.log" 2>&1 || true
+
+# Disk and mount information
+echo "Collecting disk/mount info..."
+lsblk -f > "$DIAG_DIR/lsblk.txt" 2>&1 || true
+blkid > "$DIAG_DIR/blkid.txt" 2>&1 || true
+df -h > "$DIAG_DIR/df.txt" 2>&1 || true
+mount > "$DIAG_DIR/mount.txt" 2>&1 || true
+cat /etc/fstab > "$DIAG_DIR/fstab.txt" 2>/dev/null || true
+cat /etc/resilio-sync/folder-device-map.json > "$DIAG_DIR/folder-device-map.json" 2>/dev/null || true
+
+# Service status
+echo "Collecting service status..."
+systemctl status resilio-sync > "$DIAG_DIR/status-resilio-sync.txt" 2>&1 || true
+systemctl status cloud-init > "$DIAG_DIR/status-cloud-init.txt" 2>&1 || true
+systemctl status cloud-final > "$DIAG_DIR/status-cloud-final.txt" 2>&1 || true
+systemctl status volume-auto-expand > "$DIAG_DIR/status-volume-expand.txt" 2>&1 || true
+systemctl list-units --failed > "$DIAG_DIR/failed-units.txt" 2>&1 || true
+
+# Configuration files (sanitized)
+echo "Collecting configuration..."
+cat /etc/resilio-sync/config.json | jq 'del(.shared_folders[].secret)' > "$DIAG_DIR/resilio-config-sanitized.json" 2>/dev/null || true
+
+# System info
+echo "Collecting system info..."
+uname -a > "$DIAG_DIR/uname.txt" 2>&1 || true
+hostname -f > "$DIAG_DIR/hostname.txt" 2>&1 || true
+cat /etc/os-release > "$DIAG_DIR/os-release.txt" 2>/dev/null || true
+free -h > "$DIAG_DIR/memory.txt" 2>&1 || true
+
+# Create tarball
+echo "Creating tarball..."
+tar -czf "$DIAG_TAR" -C /tmp "$(basename $DIAG_DIR)"
+rm -rf "$DIAG_DIR"
+
+echo ""
+echo "=== Diagnostics collected ==="
+echo "File: $DIAG_TAR"
+echo "Size: $(du -h $DIAG_TAR | cut -f1)"
+echo ""
+echo "To download via SSH:"
+echo "  scp -J ac-user@<jumpbox> ac-user@$(hostname -f):$DIAG_TAR ."
+echo ""
+echo "Or view directly:"
+echo "  tar -tzf $DIAG_TAR"

--- a/scripts/cloud-init/resilio-backup-watch.sh.tpl
+++ b/scripts/cloud-init/resilio-backup-watch.sh.tpl
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Watches for file changes and triggers incremental backups
+# Used in realtime and hybrid backup modes
+
+CONFIG_FILE="/etc/resilio-sync/backup-config.json"
+DEVICE_MAP="/etc/resilio-sync/folder-device-map.json"
+BASE_MOUNT="${base_mount_point}"
+LOG_FILE="/var/log/resilio-backup-watch.log"
+
+log() {
+  echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1" >> "$LOG_FILE"
+}
+
+# Check if inotifywait is available
+if ! command -v inotifywait &>/dev/null; then
+  log "ERROR: inotifywait not found. Install inotify-tools."
+  exit 1
+fi
+
+# Get folders to watch
+if [ -f "$DEVICE_MAP" ]; then
+  WATCH_DIRS=$(jq -r '.[] | .mount_point' "$DEVICE_MAP" | tr '\n' ' ')
+else
+  WATCH_DIRS="$BASE_MOUNT"
+fi
+
+log "Starting realtime backup watcher for: $WATCH_DIRS"
+
+# Debounce: wait for changes to settle before backing up
+DEBOUNCE_SECS=30
+LAST_BACKUP=0
+
+inotifywait -m -r -e modify,create,delete,move $WATCH_DIRS 2>/dev/null | while read -r DIR EVENT FILE; do
+  # Skip sync metadata files
+  [[ "$FILE" == *".sync"* ]] && continue
+  [[ "$FILE" == *".!sync"* ]] && continue
+
+  NOW=$(date +%s)
+  ELAPSED=$((NOW - LAST_BACKUP))
+
+  if [ $ELAPSED -ge $DEBOUNCE_SECS ]; then
+    log "Change detected: $DIR$FILE ($EVENT) - triggering backup"
+    /usr/local/bin/resilio-backup.sh &
+    LAST_BACKUP=$NOW
+  fi
+done

--- a/scripts/cloud-init/resilio-backup.sh.tpl
+++ b/scripts/cloud-init/resilio-backup.sh.tpl
@@ -1,0 +1,108 @@
+#!/bin/bash
+# Enhanced backup script - supports versioning, multi-region, and smart scheduling
+set -euo pipefail
+
+# Configuration
+CONFIG_FILE="/etc/resilio-sync/backup-config.json"
+DEVICE_MAP="/etc/resilio-sync/folder-device-map.json"
+BASE_MOUNT="${base_mount_point}"
+LOG_FILE="/var/log/resilio-backup.log"
+LOCK_FILE="/var/run/resilio-backup.lock"
+
+# Read config
+if [ -f "$CONFIG_FILE" ]; then
+  TRANSFERS=$(jq -r '.transfers // 8' "$CONFIG_FILE")
+  BANDWIDTH=$(jq -r '.bandwidth_limit // ""' "$CONFIG_FILE")
+  RETENTION_DAYS=$(jq -r '.retention_days // 90' "$CONFIG_FILE")
+  VERSIONING=$(jq -r '.versioning // true' "$CONFIG_FILE")
+else
+  TRANSFERS=8
+  BANDWIDTH=""
+  RETENTION_DAYS=90
+  VERSIONING=true
+fi
+
+# Build rclone options
+RCLONE_OPTS="--transfers $TRANSFERS --log-file=$LOG_FILE --log-level INFO"
+RCLONE_OPTS="$RCLONE_OPTS --exclude '.sync/StreamsList' --exclude '.sync/DownloadState' --exclude '*.!sync'"
+[ -n "$BANDWIDTH" ] && RCLONE_OPTS="$RCLONE_OPTS --bwlimit $BANDWIDTH"
+
+# Logging helper
+log() {
+  echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1" | tee -a "$LOG_FILE"
+}
+
+# Acquire lock to prevent concurrent backups
+exec 200>"$LOCK_FILE"
+if ! flock -n 200; then
+  log "Another backup is already running, exiting"
+  exit 0
+fi
+
+# Get hostname for backup path
+HOSTNAME=$(hostname -f)
+
+log "=== Starting backup ==="
+log "Host: $HOSTNAME"
+log "Transfers: $TRANSFERS, Bandwidth: $${BANDWIDTH:-unlimited}"
+log "Versioning: $VERSIONING, Retention: $RETENTION_DAYS days"
+
+# Get list of rclone remotes (backup destinations)
+REMOTES=$(rclone listremotes 2>/dev/null | grep -E '^(r|backup-)' || echo "r:")
+
+# Determine sync command based on versioning
+if [ "$VERSIONING" = "true" ]; then
+  SYNC_CMD="copy"  # Use copy to preserve versions
+  log "Using copy mode (versioning enabled)"
+else
+  SYNC_CMD="sync"  # Use sync for exact mirror
+  log "Using sync mode (versioning disabled)"
+fi
+
+ERRORS=0
+
+# Backup each folder
+if [ -f "$DEVICE_MAP" ]; then
+  FOLDERS=$(jq -r 'to_entries[] | "\(.key)|\(.value.mount_point)"' "$DEVICE_MAP")
+else
+  # Fallback to single base mount
+  FOLDERS="data|$BASE_MOUNT"
+fi
+
+echo "$FOLDERS" | while IFS='|' read -r FOLDER_NAME MOUNT_POINT; do
+  [ -z "$FOLDER_NAME" ] && continue
+
+  log "Backing up folder: $FOLDER_NAME from $MOUNT_POINT"
+
+  # Backup to each remote
+  for REMOTE in $REMOTES; do
+    REMOTE_NAME=$(echo "$REMOTE" | tr -d ':')
+    BUCKET=$(rclone config show "$REMOTE_NAME" 2>/dev/null | grep -E '^bucket' | cut -d= -f2 | tr -d ' ' || echo "${object_storage_bucket}")
+    [ -z "$BUCKET" ] && BUCKET="${object_storage_bucket}"
+
+    DEST="$REMOTE$BUCKET/$HOSTNAME/$FOLDER_NAME"
+    log "  -> $DEST"
+
+    if eval rclone $SYNC_CMD "$MOUNT_POINT" "$DEST" $RCLONE_OPTS; then
+      log "  Backup complete to $REMOTE_NAME"
+    else
+      log "  ERROR: Backup failed to $REMOTE_NAME"
+      ERRORS=$((ERRORS + 1))
+    fi
+  done
+done
+
+# Cleanup old versions (only if retention is set)
+if [ "$RETENTION_DAYS" -gt 0 ]; then
+  log "Cleaning up files older than $RETENTION_DAYS days..."
+  for REMOTE in $REMOTES; do
+    REMOTE_NAME=$(echo "$REMOTE" | tr -d ':')
+    BUCKET=$(rclone config show "$REMOTE_NAME" 2>/dev/null | grep -E '^bucket' | cut -d= -f2 | tr -d ' ' || echo "${object_storage_bucket}")
+    [ -z "$BUCKET" ] && BUCKET="${object_storage_bucket}"
+
+    rclone delete "$REMOTE$BUCKET/$HOSTNAME" --min-age "$${RETENTION_DAYS}d" >> "$LOG_FILE" 2>&1 || true
+  done
+fi
+
+log "=== Backup complete (errors: $ERRORS) ==="
+exit $ERRORS

--- a/scripts/cloud-init/resilio-folders.sh.tpl
+++ b/scripts/cloud-init/resilio-folders.sh.tpl
@@ -13,9 +13,9 @@ generate_config() {
     echo "Error: $FOLDERS_FILE not found" >&2
     exit 1
   fi
-  # Read folders and inject into config template
+  # Read folders and inject into config template, then pretty-print with jq
   FOLDERS=$(cat "$FOLDERS_FILE")
-  sed "s|FOLDERS_PLACEHOLDER|$FOLDERS|" "$CONFIG_TPL" > "$CONFIG"
+  sed "s|FOLDERS_PLACEHOLDER|$FOLDERS|" "$CONFIG_TPL" | jq . > "$CONFIG"
   chown rslsync:rslsync "$CONFIG"
   echo "Config regenerated at $CONFIG"
 }

--- a/scripts/cloud-init/resilio-folders.sh.tpl
+++ b/scripts/cloud-init/resilio-folders.sh.tpl
@@ -1,0 +1,117 @@
+#!/bin/bash
+# Resilio Sync Folder Manager - allows non-destructive folder changes via SSH
+# Per-folder volumes: each folder has its own volume and mount point
+set -euo pipefail
+BASE_MOUNT="${base_mount_point}"
+FOLDERS_FILE="$BASE_MOUNT/.sync/folders.json"
+DEVICE_MAP="/etc/resilio-sync/folder-device-map.json"
+CONFIG_TPL="/etc/resilio-sync/config.json.tpl"
+CONFIG="/etc/resilio-sync/config.json"
+
+generate_config() {
+  if [ ! -f "$FOLDERS_FILE" ]; then
+    echo "Error: $FOLDERS_FILE not found" >&2
+    exit 1
+  fi
+  # Read folders and inject into config template
+  FOLDERS=$(cat "$FOLDERS_FILE")
+  sed "s|FOLDERS_PLACEHOLDER|$FOLDERS|" "$CONFIG_TPL" > "$CONFIG"
+  chown rslsync:rslsync "$CONFIG"
+  echo "Config regenerated at $CONFIG"
+}
+
+case "$${1:-help}" in
+  list)
+    echo "Configured folders (from Terraform):"
+    if [ -f "$DEVICE_MAP" ]; then
+      jq -r 'to_entries[] | "  - \(.key): \(.value.mount_point) (\(.value.device_path))"' "$DEVICE_MAP"
+    fi
+    echo ""
+    echo "Active Resilio folders:"
+    if [ -f "$FOLDERS_FILE" ]; then
+      jq -r '.[] | "  - \(.dir) [\(.secret[0:8])...]"' "$FOLDERS_FILE"
+    else
+      echo "  (no folders configured)"
+    fi
+    ;;
+  add)
+    if [ -z "$${2:-}" ] || [ -z "$${3:-}" ]; then
+      echo "Usage: resilio-folders add <folder_key> <folder_name>"
+      echo "Example: resilio-folders add BXXXXXXX... documents"
+      echo ""
+      echo "NOTE: For per-folder volumes, the folder must already be defined"
+      echo "in Terraform (resilio_folders variable). This command adds the"
+      echo "folder to Resilio's config for an existing mounted volume."
+      exit 1
+    fi
+    KEY="$2"
+    FOLDER_NAME="$3"
+    FULL_PATH="$BASE_MOUNT/$FOLDER_NAME"
+    # Verify mount point exists (should be pre-created by Terraform)
+    if [ ! -d "$FULL_PATH" ]; then
+      echo "Warning: $FULL_PATH does not exist. Creating..."
+      mkdir -p "$FULL_PATH"
+    fi
+    chown rslsync:rslsync "$FULL_PATH"
+    # Add to folders.json
+    jq --arg key "$KEY" --arg dir "$FULL_PATH" \
+      '. += [{"secret": $key, "dir": $dir, "use_relay_server": true, "use_tracker": true, "search_lan": false, "use_sync_trash": true, "overwrite_changes": false, "selective_sync": false}]' \
+      "$FOLDERS_FILE" > "$FOLDERS_FILE.tmp" && mv "$FOLDERS_FILE.tmp" "$FOLDERS_FILE"
+    chown rslsync:rslsync "$FOLDERS_FILE"
+    generate_config
+    echo "Added folder: $FOLDER_NAME"
+    echo "Restart Resilio Sync to apply: sudo systemctl restart resilio-sync"
+    ;;
+  remove)
+    if [ -z "$${2:-}" ]; then
+      echo "Usage: resilio-folders remove <folder_name>"
+      echo "Note: This removes the folder from Resilio config but keeps data"
+      exit 1
+    fi
+    FOLDER_NAME="$2"
+    FULL_PATH="$BASE_MOUNT/$FOLDER_NAME"
+    jq --arg dir "$FULL_PATH" 'map(select(.dir != $dir))' \
+      "$FOLDERS_FILE" > "$FOLDERS_FILE.tmp" && mv "$FOLDERS_FILE.tmp" "$FOLDERS_FILE"
+    chown rslsync:rslsync "$FOLDERS_FILE"
+    generate_config
+    echo "Removed folder: $FOLDER_NAME (data NOT deleted)"
+    echo "Restart Resilio Sync to apply: sudo systemctl restart resilio-sync"
+    ;;
+  status)
+    echo "Volume Status:"
+    if [ -f "$DEVICE_MAP" ]; then
+      jq -r 'to_entries[] | .value | "\(.device_path) \(.label) \(.mount_point)"' "$DEVICE_MAP" | \
+      while read -r DEV LABEL MOUNT; do
+        SIZE=$(df -h "$MOUNT" 2>/dev/null | tail -1 | awk '{print $2}')
+        USED=$(df -h "$MOUNT" 2>/dev/null | tail -1 | awk '{print $3}')
+        AVAIL=$(df -h "$MOUNT" 2>/dev/null | tail -1 | awk '{print $4}')
+        echo "  $LABEL: $USED used / $SIZE total ($AVAIL available)"
+      done
+    fi
+    ;;
+  regenerate)
+    generate_config
+    ;;
+  apply)
+    generate_config
+    systemctl restart resilio-sync
+    echo "Config applied and Resilio Sync restarted"
+    ;;
+  *)
+    echo "Resilio Sync Folder Manager (Per-Folder Volumes)"
+    echo ""
+    echo "Usage: resilio-folders <command> [args]"
+    echo ""
+    echo "Commands:"
+    echo "  list                     - List configured folders and volumes"
+    echo "  status                   - Show volume disk usage"
+    echo "  add <key> <folder>       - Add a new folder to Resilio config"
+    echo "  remove <folder>          - Remove a folder (keeps data)"
+    echo "  regenerate               - Regenerate config from folders.json"
+    echo "  apply                    - Regenerate config and restart service"
+    echo ""
+    echo "Config files:"
+    echo "  Folders: $FOLDERS_FILE"
+    echo "  Device map: $DEVICE_MAP"
+    ;;
+esac

--- a/scripts/cloud-init/resilio-rehydrate.sh.tpl
+++ b/scripts/cloud-init/resilio-rehydrate.sh.tpl
@@ -1,0 +1,134 @@
+#!/bin/bash
+# Rehydration script - restore from backup to new/rebuilt VMs
+set -euo pipefail
+
+# Configuration
+DEVICE_MAP="/etc/resilio-sync/folder-device-map.json"
+BASE_MOUNT="${base_mount_point}"
+LOG_FILE="/var/log/resilio-rehydrate.log"
+
+log() {
+  echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1" | tee -a "$LOG_FILE"
+}
+
+usage() {
+  echo "Usage: $0 [options]"
+  echo ""
+  echo "Restore data from Object Storage backup to this VM."
+  echo "Use this to quickly rehydrate a new or rebuilt VM."
+  echo ""
+  echo "Options:"
+  echo "  -s, --source HOSTNAME   Source hostname to restore from (default: auto-detect)"
+  echo "  -f, --folder NAME       Only restore specific folder (default: all)"
+  echo "  -r, --remote NAME       Rclone remote to restore from (default: r:)"
+  echo "  -l, --list              List available backups"
+  echo "  -n, --dry-run           Show what would be restored without making changes"
+  echo "  -h, --help              Show this help"
+  echo ""
+  echo "Examples:"
+  echo "  $0 --list                           # List available backups"
+  echo "  $0                                  # Restore all folders from most recent"
+  echo "  $0 --source old-server.example.com # Restore from specific host"
+  echo "  $0 --folder documents              # Restore only documents folder"
+  echo "  $0 --dry-run                       # Preview restore operation"
+}
+
+# Parse arguments
+SOURCE_HOST=""
+FOLDER_FILTER=""
+REMOTE="r:"
+DRY_RUN=""
+LIST_ONLY=""
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    -s|--source) SOURCE_HOST="$2"; shift 2 ;;
+    -f|--folder) FOLDER_FILTER="$2"; shift 2 ;;
+    -r|--remote) REMOTE="$2:"; shift 2 ;;
+    -l|--list) LIST_ONLY="1"; shift ;;
+    -n|--dry-run) DRY_RUN="--dry-run"; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown option: $1"; usage; exit 1 ;;
+  esac
+done
+
+BUCKET="${object_storage_bucket}"
+
+# List available backups
+if [ -n "$LIST_ONLY" ]; then
+  log "Available backups in $REMOTE$BUCKET:"
+  rclone lsd "$REMOTE$BUCKET" 2>/dev/null | awk '{print "  " $NF}'
+  exit 0
+fi
+
+# Auto-detect source host if not specified
+if [ -z "$SOURCE_HOST" ]; then
+  # Try to find backups matching our project pattern
+  AVAILABLE=$(rclone lsd "$REMOTE$BUCKET" 2>/dev/null | awk '{print $NF}' | head -1)
+  if [ -z "$AVAILABLE" ]; then
+    log "ERROR: No backups found in $REMOTE$BUCKET"
+    log "Use --list to see available backups or --source to specify hostname"
+    exit 1
+  fi
+  SOURCE_HOST="$AVAILABLE"
+  log "Auto-detected source: $SOURCE_HOST"
+fi
+
+log "=== Starting rehydration ==="
+log "Source: $REMOTE$BUCKET/$SOURCE_HOST"
+log "Destination: $BASE_MOUNT"
+[ -n "$DRY_RUN" ] && log "DRY RUN MODE - no changes will be made"
+
+# Stop Resilio Sync during restore
+log "Stopping Resilio Sync..."
+systemctl stop resilio-sync || true
+
+ERRORS=0
+
+# Determine folders to restore
+if [ -f "$DEVICE_MAP" ]; then
+  if [ -n "$FOLDER_FILTER" ]; then
+    FOLDERS="$FOLDER_FILTER|$(jq -r --arg f "$FOLDER_FILTER" '.[$f].mount_point // ""' "$DEVICE_MAP")"
+  else
+    FOLDERS=$(jq -r 'to_entries[] | "\(.key)|\(.value.mount_point)"' "$DEVICE_MAP")
+  fi
+else
+  FOLDERS="data|$BASE_MOUNT"
+fi
+
+echo "$FOLDERS" | while IFS='|' read -r FOLDER_NAME MOUNT_POINT; do
+  [ -z "$FOLDER_NAME" ] && continue
+  [ -z "$MOUNT_POINT" ] && MOUNT_POINT="$BASE_MOUNT/$FOLDER_NAME"
+
+  SOURCE="$REMOTE$BUCKET/$SOURCE_HOST/$FOLDER_NAME"
+  log "Restoring: $SOURCE -> $MOUNT_POINT"
+
+  # Check if source exists
+  if ! rclone lsd "$SOURCE" &>/dev/null && ! rclone ls "$SOURCE" &>/dev/null 2>&1; then
+    log "  WARNING: Source $SOURCE not found, skipping"
+    continue
+  fi
+
+  # Ensure mount point exists
+  mkdir -p "$MOUNT_POINT"
+
+  # Restore data
+  if rclone copy "$SOURCE" "$MOUNT_POINT" $DRY_RUN \
+    --transfers 8 --log-file="$LOG_FILE" --log-level INFO \
+    --exclude ".sync/StreamsList" --exclude ".sync/DownloadState"; then
+    log "  Restore complete"
+    [ -z "$DRY_RUN" ] && chown -R rslsync:rslsync "$MOUNT_POINT"
+  else
+    log "  ERROR: Restore failed"
+    ERRORS=$((ERRORS + 1))
+  fi
+done
+
+# Restart Resilio Sync
+if [ -z "$DRY_RUN" ]; then
+  log "Starting Resilio Sync..."
+  systemctl start resilio-sync
+fi
+
+log "=== Rehydration complete (errors: $ERRORS) ==="
+exit $ERRORS

--- a/scripts/cloud-init/volume-auto-expand.sh.tpl
+++ b/scripts/cloud-init/volume-auto-expand.sh.tpl
@@ -1,0 +1,98 @@
+#!/bin/bash
+# Automatically expand filesystems if volumes have been resized
+# Runs on boot via systemd before resilio-sync starts
+# Handles multiple per-folder volumes with label-based detection
+set -euo pipefail
+
+DEVICE_MAP="/etc/resilio-sync/folder-device-map.json"
+BASE_MOUNT="${base_mount_point}"
+LOG="/var/log/volume-expand.log"
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1" | tee -a "$LOG"; }
+
+expand_volume() {
+  local DEVICE="$1"
+  local PARTITION="$2"
+  local LABEL="$3"
+  local EXPECTED_MOUNT="$4"
+
+  # Check if partition exists
+  if [ ! -b "$PARTITION" ]; then
+    log "[$LABEL] Partition $PARTITION not found, skipping"
+    return 0
+  fi
+
+  # DUAL VERIFICATION: Check both label AND mount point match expected values
+  # This prevents accidental expansion of wrong volumes
+  ACTUAL_LABEL=$(blkid -s LABEL -o value "$PARTITION" 2>/dev/null || echo "")
+  ACTUAL_MOUNT=$(findmnt -n -o TARGET "$PARTITION" 2>/dev/null || echo "")
+
+  if [ "$ACTUAL_LABEL" != "$LABEL" ]; then
+    log "[$LABEL] WARNING: Label mismatch - expected '$LABEL', found '$ACTUAL_LABEL'. Skipping."
+    return 1
+  fi
+
+  if [ -n "$ACTUAL_MOUNT" ] && [ "$ACTUAL_MOUNT" != "$EXPECTED_MOUNT" ]; then
+    log "[$LABEL] WARNING: Mount mismatch - expected '$EXPECTED_MOUNT', found '$ACTUAL_MOUNT'. Skipping."
+    return 1
+  fi
+
+  # Verify mount point is under our base directory (safety check)
+  if [[ "$EXPECTED_MOUNT" != "$BASE_MOUNT"/* ]]; then
+    log "[$LABEL] WARNING: Mount point $EXPECTED_MOUNT is not under $BASE_MOUNT. Skipping."
+    return 1
+  fi
+
+  # Get sizes in bytes
+  DEVICE_SIZE=$(blockdev --getsize64 "$DEVICE")
+  PART_SIZE=$(blockdev --getsize64 "$PARTITION")
+
+  # Calculate difference (account for GPT overhead ~1MB)
+  DIFF=$((DEVICE_SIZE - PART_SIZE))
+  THRESHOLD=$((100 * 1024 * 1024))  # 100MB threshold
+
+  if [ "$DIFF" -gt "$THRESHOLD" ]; then
+    log "[$LABEL] Volume resize detected: device=$((DEVICE_SIZE/1024/1024))MB, partition=$((PART_SIZE/1024/1024))MB"
+    log "[$LABEL] Expanding partition..."
+
+    # Grow partition to fill device
+    if growpart "$DEVICE" 1; then
+      log "[$LABEL] Partition expanded successfully"
+    else
+      log "[$LABEL] ERROR: Failed to expand partition"
+      return 1
+    fi
+
+    # Resize filesystem (works online for ext4)
+    log "[$LABEL] Expanding filesystem..."
+    if resize2fs "$PARTITION"; then
+      NEW_SIZE=$(blockdev --getsize64 "$PARTITION")
+      log "[$LABEL] Filesystem expanded successfully: $((NEW_SIZE/1024/1024))MB"
+    else
+      log "[$LABEL] ERROR: Failed to expand filesystem"
+      return 1
+    fi
+  else
+    log "[$LABEL] No expansion needed: device and partition sizes match"
+  fi
+}
+
+log "Starting volume auto-expansion check..."
+
+# Check if device map exists
+if [ ! -f "$DEVICE_MAP" ]; then
+  log "No device map found at $DEVICE_MAP, skipping"
+  exit 0
+fi
+
+# Process each volume from the device map
+ERRORS=0
+jq -r 'to_entries[] | "\(.value.device_path) \(.value.partition) \(.value.label) \(.value.mount_point)"' "$DEVICE_MAP" | \
+while read -r DEVICE PARTITION LABEL MOUNT; do
+  if ! expand_volume "$DEVICE" "$PARTITION" "$LABEL" "$MOUNT"; then
+    ERRORS=$((ERRORS + 1))
+  fi
+done
+
+log "Volume auto-expansion check complete"
+exit 0

--- a/tags.tf
+++ b/tags.tf
@@ -2,9 +2,10 @@
 locals {
   tags = concat(
     var.tags, [
-      "tld: ${var.tld}",              # e.g. "tld: test.com"
-      "project: ${var.project_name}", # e.g. "project: resilio-sync"
-      "user: ${var.cloud_user}"       # e.g. "user: ac-user"
+      "tld: ${var.tld}",                         # e.g. "tld: test.com"
+      "project: ${var.project_name}",            # e.g. "project: resilio-sync"
+      "user: ${var.cloud_user}",                 # e.g. "user: ac-user"
+      "suffix: ${random_id.global_suffix.hex}"   # e.g. "suffix: a1b2c3d4" - shared across all VMs
     ]
   )
 }

--- a/tags.tf
+++ b/tags.tf
@@ -2,10 +2,10 @@
 locals {
   tags = concat(
     var.tags, [
-      "tld: ${var.tld}",                         # e.g. "tld: test.com"
-      "project: ${var.project_name}",            # e.g. "project: resilio-sync"
-      "user: ${var.cloud_user}",                 # e.g. "user: ac-user"
-      "suffix: ${random_id.global_suffix.hex}"   # e.g. "suffix: a1b2c3d4" - shared across all VMs
+      "tld: ${var.tld}",                       # e.g. "tld: test.com"
+      "project: ${var.project_name}",          # e.g. "project: resilio-sync"
+      "user: ${var.cloud_user}",               # e.g. "user: ac-user"
+      "suffix: ${random_id.global_suffix.hex}" # e.g. "suffix: a1b2c3d4" - shared across all VMs
     ]
   )
 }

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -89,40 +89,78 @@ tags = ["deployment: terraform", "app: resilio", "environment: production"]
 # cloud_user = "ac-user"
 
 # ============================================================================
+# SSL/TLS Certificate Configuration
+# ============================================================================
+
+# ACME server URL for Let's Encrypt certificates
+# Production (default): "https://acme-v02.api.letsencrypt.org/directory"
+# Staging (for testing): "https://acme-staging-v02.api.letsencrypt.org/directory"
+# IMPORTANT: Use staging for initial testing to avoid rate limits!
+# acme_server_url = "https://acme-v02.api.letsencrypt.org/directory"
+
+# ============================================================================
 # Backup Configuration - Linode Object Storage
 # ============================================================================
 
-# Linode Object Storage credentials for automated backups
-# IMPORTANT: Set these to enable daily backups to Object Storage
-# Leave as "CHANGEME" or empty to disable backups
+# Option 1: Terraform-managed backups (RECOMMENDED)
+# Set backup_enabled = true to let Terraform create and manage buckets/keys
 
-# Object Storage Access Key (get from: https://cloud.linode.com/object-storage/access-keys)
+# Enable Terraform-managed Object Storage backups
+# When true, Terraform creates buckets and access keys automatically
+# Default: false
+# backup_enabled = true
+
+# Regions for backup storage destinations (where backups are stored)
+# Backups can be replicated to multiple regions for redundancy
+# Default: ["us-east"]
+# backup_storage_regions = ["us-east", "eu-west"]
+
+# VM regions that should run backups (which VMs push to storage)
+# Only one region needed since all VMs have same data via Resilio Sync
+# Default: []
+# backup_source_regions = ["us-east"]
+
+# Enable object versioning on backup buckets (recommended)
+# Allows point-in-time recovery of files
+# Default: true
+# backup_versioning = true
+
+# Days to retain backup versions before cleanup
+# Set to 0 to keep forever
+# Default: 90
+# backup_retention_days = 90
+
+# Backup scheduling mode:
+#   "scheduled" - Traditional cron-based backups (default)
+#   "realtime"  - inotify-based immediate backup on file changes
+#   "hybrid"    - Both scheduled full + realtime incremental backups
+# Default: "scheduled"
+# backup_mode = "scheduled"
+
+# Cron schedule for backups (used in scheduled and hybrid modes)
+# Default: "0 2 * * *" (daily at 2 AM)
+# backup_schedule = "0 2 * * *"
+
+# Number of parallel file transfers (1-32)
+# Higher = faster but more CPU/IO usage
+# Default: 8
+# backup_transfers = 8
+
+# Bandwidth limit for backups (e.g., "10M" for 10MB/s)
+# Empty = unlimited
+# Default: ""
+# backup_bandwidth_limit = ""
+
+# ----------------------------------------------------------------------------
+# Option 2: Legacy manual configuration (use if backup_enabled = false)
+# ----------------------------------------------------------------------------
+
+# [LEGACY] Manual Object Storage credentials
+# Only used if backup_enabled = false
 # object_storage_access_key = "CHANGEME"
-
-# Object Storage Secret Key
 # object_storage_secret_key = "CHANGEME"
-
-# Object Storage Endpoint (region-specific)
-# Available endpoints:
-#   - us-east-1.linodeobjects.com (Newark, NJ)
-#   - us-southeast-1.linodeobjects.com (Atlanta, GA)
-#   - eu-central-1.linodeobjects.com (Frankfurt, DE)
-#   - ap-south-1.linodeobjects.com (Singapore)
-# Default: "us-east-1.linodeobjects.com"
 # object_storage_endpoint = "us-east-1.linodeobjects.com"
-
-# Object Storage Bucket name (must be created in Linode Object Storage first)
-# Default: "resilio-backups"
 # object_storage_bucket = "resilio-backups"
 
-# Which regions should run backups (to avoid redundant backups across all regions)
-# Since Resilio syncs data across all regions, only ONE region needs to backup
-# Default: [] (no backups). Set to ["us-east"] to enable on one region.
-backup_regions = ["us-east"]
-
-# Backup Schedule:
-# - Daily backups run at 2:00 AM local time
-# - Incremental backups (only changed files)
-# - Old backups deleted after 30 days
-# - Backup location: <bucket>/<hostname>/<folder>/
-# - NOTE: Create the bucket in Linode Object Storage before enabling backups
+# [DEPRECATED] Use backup_source_regions instead
+# backup_regions = ["us-east"]

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -111,9 +111,16 @@ tags = ["deployment: terraform", "app: resilio", "environment: production"]
 # backup_enabled = true
 
 # Regions for backup storage destinations (where backups are stored)
-# Backups can be replicated to multiple regions for redundancy
-# Default: ["us-east"]
-# backup_storage_regions = ["us-east", "eu-west"]
+# IMPORTANT: Object Storage uses different region IDs than compute instances!
+# Compute regions: us-east, eu-west, ap-south, etc.
+# Object Storage regions: us-east-1, eu-central-1, ap-south-1, etc.
+# Valid Object Storage regions:
+#   us-east-1, us-southeast-1, us-iad-1, us-ord-1, us-sea-1 (Americas)
+#   eu-central-1, fr-par-1, se-sto-1 (Europe)
+#   ap-south-1, jp-osa-1, in-maa-1, id-cgk-1, au-mel-1 (Asia-Pacific)
+#   br-gru-1 (South America)
+# Default: ["us-east-1"]
+# backup_storage_regions = ["us-east-1", "eu-central-1"]
 
 # VM regions that should run backups (which VMs push to storage)
 # Only one region needed since all VMs have same data via Resilio Sync

--- a/variables.tf
+++ b/variables.tf
@@ -174,9 +174,32 @@ variable "backup_enabled" {
 }
 
 variable "backup_storage_regions" {
-  description = "List of Linode regions for backup storage destinations (e.g., ['us-east', 'eu-west']). Backups are replicated to all specified regions."
+  description = "List of Linode Object Storage regions for backup destinations. Note: Object Storage uses different region IDs than compute (e.g., 'us-east-1' not 'us-east')."
   type        = list(string)
-  default     = ["us-east"]
+  default     = ["us-east-1"]
+
+  validation {
+    condition = alltrue([
+      for region in var.backup_storage_regions :
+      contains([
+        "us-east-1",      # Newark, NJ
+        "us-southeast-1", # Atlanta, GA
+        "us-iad-1",       # Washington, DC
+        "us-ord-1",       # Chicago, IL
+        "us-sea-1",       # Seattle, WA
+        "eu-central-1",   # Frankfurt, Germany
+        "fr-par-1",       # Paris, France
+        "se-sto-1",       # Stockholm, Sweden
+        "ap-south-1",     # Singapore
+        "jp-osa-1",       # Osaka, Japan
+        "in-maa-1",       # Chennai, India
+        "id-cgk-1",       # Jakarta, Indonesia
+        "br-gru-1",       # São Paulo, Brazil
+        "au-mel-1",       # Melbourne, Australia
+      ], region)
+    ])
+    error_message = "Invalid Object Storage region. Valid regions: us-east-1, us-southeast-1, us-iad-1, us-ord-1, us-sea-1, eu-central-1, fr-par-1, se-sto-1, ap-south-1, jp-osa-1, in-maa-1, id-cgk-1, br-gru-1, au-mel-1. Note: Object Storage regions differ from compute regions."
+  }
 }
 
 variable "backup_source_regions" {

--- a/variables.tf
+++ b/variables.tf
@@ -127,6 +127,13 @@ variable "create_domain" {
   default     = false # Default to false since most users will have existing domains
 }
 
+variable "acme_server_url" {
+  description = "ACME server URL for Let's Encrypt certificates. Use staging for testing to avoid rate limits."
+  type        = string
+  default     = "https://acme-v02.api.letsencrypt.org/directory"
+  # Staging URL: "https://acme-staging-v02.api.letsencrypt.org/directory"
+}
+
 variable "tags" {
   description = "Set of tags to apply to all resources"
   type        = list(string)

--- a/variables.tf
+++ b/variables.tf
@@ -156,36 +156,132 @@ variable "jumpbox_instance_type" {
   default     = "g6-nanode-1" # Smallest instance (1GB RAM, 1 vCPU) - sufficient for jumpbox
 }
 
+# =============================================================================
+# BACKUP CONFIGURATION
+# =============================================================================
+
+variable "backup_enabled" {
+  description = "Enable Object Storage backups. When true, Terraform will create and manage backup buckets and keys."
+  type        = bool
+  default     = false
+}
+
+variable "backup_storage_regions" {
+  description = "List of Linode regions for backup storage destinations (e.g., ['us-east', 'eu-west']). Backups are replicated to all specified regions."
+  type        = list(string)
+  default     = ["us-east"]
+
+  validation {
+    condition     = length(var.backup_storage_regions) > 0 || !var.backup_enabled
+    error_message = "At least one backup storage region must be specified when backups are enabled."
+  }
+}
+
+variable "backup_source_regions" {
+  description = "List of VM regions that should run backups. Only VMs in these regions will push to Object Storage. Empty = no VMs backup."
+  type        = list(string)
+  default     = [] # Set to ["us-east"] to have one region backup
+
+  validation {
+    condition     = length(var.backup_source_regions) <= 1 || !var.backup_enabled
+    error_message = "For efficiency, only one source region should run backups since all VMs have the same data via Resilio Sync."
+  }
+}
+
+variable "backup_versioning" {
+  description = "Enable object versioning for backup buckets (recommended for data protection and recovery)"
+  type        = bool
+  default     = true
+}
+
+variable "backup_retention_days" {
+  description = "Number of days to retain backup versions. Old versions are automatically cleaned up. Set to 0 to keep forever."
+  type        = number
+  default     = 90
+
+  validation {
+    condition     = var.backup_retention_days >= 0
+    error_message = "Retention days must be 0 or greater."
+  }
+}
+
+variable "backup_mode" {
+  description = "Backup scheduling mode: 'scheduled' (cron-based), 'realtime' (inotify-based immediate sync), or 'hybrid' (realtime + daily full sync)"
+  type        = string
+  default     = "scheduled"
+
+  validation {
+    condition     = contains(["scheduled", "realtime", "hybrid"], var.backup_mode)
+    error_message = "Backup mode must be 'scheduled', 'realtime', or 'hybrid'."
+  }
+}
+
+variable "backup_schedule" {
+  description = "Cron schedule for backups (used in 'scheduled' and 'hybrid' modes). Default: daily at 2 AM."
+  type        = string
+  default     = "0 2 * * *"
+}
+
+variable "backup_transfers" {
+  description = "Number of parallel file transfers for rclone (higher = faster but more CPU/IO)"
+  type        = number
+  default     = 8
+
+  validation {
+    condition     = var.backup_transfers >= 1 && var.backup_transfers <= 32
+    error_message = "Backup transfers must be between 1 and 32."
+  }
+}
+
+variable "backup_bandwidth_limit" {
+  description = "Bandwidth limit for backups in bytes/sec (e.g., '10M' for 10MB/s). Empty string = unlimited."
+  type        = string
+  default     = ""
+}
+
+variable "backup_bucket_prefix" {
+  description = "Prefix for backup bucket names (will be suffixed with region)"
+  type        = string
+  default     = "resilio-backup"
+
+  validation {
+    condition     = can(regex("^[a-z0-9][a-z0-9-]*[a-z0-9]$", var.backup_bucket_prefix)) || var.backup_bucket_prefix == ""
+    error_message = "Bucket prefix must be lowercase alphanumeric with hyphens."
+  }
+}
+
+# Legacy variables - kept for backward compatibility
+# These are used if backup_enabled = false and manual credentials are provided
 variable "object_storage_access_key" {
-  description = "Linode Object Storage access key for backups. Set to empty string or 'CHANGEME' to disable backups."
+  description = "[LEGACY] Manual Object Storage access key. Use backup_enabled=true for Terraform-managed backups."
   type        = string
   sensitive   = true
   default     = "CHANGEME"
 }
 
 variable "object_storage_secret_key" {
-  description = "Linode Object Storage secret key for backups"
+  description = "[LEGACY] Manual Object Storage secret key. Use backup_enabled=true for Terraform-managed backups."
   type        = string
   sensitive   = true
   default     = "CHANGEME"
 }
 
 variable "object_storage_endpoint" {
-  description = "Linode Object Storage endpoint (e.g., us-east-1.linodeobjects.com)"
+  description = "[LEGACY] Manual Object Storage endpoint. Use backup_enabled=true for Terraform-managed backups."
   type        = string
   default     = "us-east-1.linodeobjects.com"
 }
 
 variable "object_storage_bucket" {
-  description = "Linode Object Storage bucket name for backups"
+  description = "[LEGACY] Manual Object Storage bucket. Use backup_enabled=true for Terraform-managed backups."
   type        = string
   default     = "resilio-backups"
 }
 
 variable "backup_regions" {
-  description = "List of regions that should run Object Storage backups. Only these regions will have backup cron jobs. Empty list disables backups on all regions."
+  description = "[DEPRECATED] Use backup_source_regions instead. List of VM regions that should run backups."
   type        = list(string)
-  default     = [] # Set to ["us-east"] to enable backups on one region only
+  default     = []
 }
 
 variable "cloud_user" {

--- a/variables.tf
+++ b/variables.tf
@@ -177,22 +177,12 @@ variable "backup_storage_regions" {
   description = "List of Linode regions for backup storage destinations (e.g., ['us-east', 'eu-west']). Backups are replicated to all specified regions."
   type        = list(string)
   default     = ["us-east"]
-
-  validation {
-    condition     = length(var.backup_storage_regions) > 0 || !var.backup_enabled
-    error_message = "At least one backup storage region must be specified when backups are enabled."
-  }
 }
 
 variable "backup_source_regions" {
-  description = "List of VM regions that should run backups. Only VMs in these regions will push to Object Storage. Empty = no VMs backup."
+  description = "List of VM regions that should run backups. Only VMs in these regions will push to Object Storage. Empty = no VMs backup. For efficiency, recommend only one region since all VMs sync the same data."
   type        = list(string)
   default     = [] # Set to ["us-east"] to have one region backup
-
-  validation {
-    condition     = length(var.backup_source_regions) <= 1 || !var.backup_enabled
-    error_message = "For efficiency, only one source region should run backups since all VMs have the same data via Resilio Sync."
-  }
 }
 
 variable "backup_versioning" {


### PR DESCRIPTION
- Create global random_id suffix shared across all VMs, firewalls, and resources
- Remove per-module random_id generation in favor of passed-in suffix
- Add suffix tag to all resources for easy identification
- Add ACME provider for Let's Encrypt certificate management
- Configure DNS-01 challenge validation using Linode DNS
- Generate wildcard SSL certificate covering all Resilio instances
- Update cloud-init to install SSL certificates for Resilio HTTPS web UI
- Configure Resilio Sync web UI to use HTTPS on port 8888
- Update firewall rules to allow HTTPS web UI access from jumpbox
- Add outputs for global suffix, SSL certificate domains, and expiry date