### PR TITLE
fix: relax jumpbox random provider constraint to allow 4.x

### DIFF
--- a/modules/jumpbox/versions.tf
+++ b/modules/jumpbox/versions.tf
@@ -9,7 +9,7 @@ terraform {
     }
     random = {
       source  = "hashicorp/random"
-      version = "~> 3.7"
+      version = ">= 3.7.0"
     }
   }
 }


### PR DESCRIPTION
Follow-up to #38, closing the last instance of the same class of bug.

## Problem

`modules/jumpbox/versions.tf` pins `hashicorp/random` to `~> 3.7`, which caps the provider below `4.0`.

This is currently **latent** — `terraform init` passes today, because root is on random 3.9.0. But it is the identical shape to the `linode/linode` constraint that broke `init` in #38: the moment the root module moves past 3.x (via Dependabot, as happened for linode in 0536b95), the two constraints have an empty intersection and provider resolution fails for the whole configuration.

## Change

`~> 3.7` → `>= 3.7.0`, matching the sibling modules:

| Module | random constraint |
|---|---|
| `modules/firewall` | `>= 3.7.0` |
| `modules/jumpbox-firewall` | `>= 3.7.0` |
| `modules/resilio-firewall` | `>= 3.7.0` |
| `modules/linode` | `>= 3.7.2` |
| `modules/jumpbox` | `~> 3.7` → **`>= 3.7.0`** |

Root `provider.tf` keeps `~> 3.7` — child modules declare a floor, the root module owns the pin.

This was the last `~>` constraint in any child module:

```
$ grep -rn --include='versions.tf' 'version *= *"~>' modules/
(no matches)
```

## Verification

```
terraform init                  → exit 0
terraform validate              → Success! The configuration is valid.
terraform fmt -recursive -check → exit 0
```

No behaviour change — provider resolution only, no resource configuration touched. Resolved random version is unchanged at 3.9.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)