### PR TITLE
chore(dependabot): cover github-actions and child module providers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,50 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
+# Dependabot version updates.
 # https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+#
+# Coverage notes:
+#   - Terraform: root `provider.tf` pins with `~>`; child modules under
+#     `modules/*/versions.tf` declare `>=` floors. Both are scanned so a
+#     pessimistic constraint reintroduced in a child module is caught before it
+#     caps the whole configuration (see PRs #38/#39).
+#   - GitHub Actions: covers all of .github/workflows/. Dependabot updates both
+#     tag refs and full SHA pins (rewriting the trailing version comment).
+#   - `.pre-commit-config.yaml` is NOT covered — Dependabot has no pre-commit
+#     ecosystem. Bump those `rev:` values with `pre-commit autoupdate`.
 
 version: 2
 updates:
-  - package-ecosystem: "terraform" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "terraform"
+    directories:
+      - "/"
+      - "/modules/*"
     schedule:
       interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    groups:
+      terraform-providers:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## Problem

Dependabot scanned only the repository root (`directory: "/"`), leaving two ecosystems unmonitored.

**1. `github-actions` was absent entirely.** No workflow action ref was ever updated.

**2. `modules/*/versions.tf` were never read.** This is the mechanism behind the `terraform init` failure fixed in #38/#39. Terraform intersects provider constraints across every module in the graph, but Dependabot only saw the root — so it moved `provider.tf` to `linode ~> 4.1` while `modules/jumpbox/versions.tf` kept `~> 3.6`. Empty intersection, no resolvable version. The two drifted silently for months because nothing was watching the child modules.

## Changes

| | Before | After |
|---|---|---|
| Terraform scope | `/` | `/` + `/modules/*` (8 modules) |
| GitHub Actions | not configured | `/` |
| PR grouping | none | minor/patch batched per ecosystem |
| PR limit | unset (default 5) | explicit 5 |
| Commit prefix | default | `chore(scope):` |

Major bumps stay ungrouped so they get individual review.

## Why `/modules/*` is low-noise

The child modules declare `>=` floors, which any newer version already satisfies — Dependabot opens no PR for them in the normal case. It fires only if a pessimistic `~>` constraint is reintroduced into a child module, which is exactly the regression that broke #38/#39.

## Not covered

`.pre-commit-config.yaml` — Dependabot has no pre-commit ecosystem. Those three pinned `rev:` values need `pre-commit autoupdate` by hand. Documented in the file header so the gap is visible rather than assumed-covered.

## Verification

- YAML parsed and structure checked
- Confirmed all 8 `modules/*/versions.tf` exist and declare `required_providers`
- Branched from `origin/main`, single file changed

## Follow-up (not in this PR)

Four action refs are tag-pinned rather than SHA-pinned (`actions/checkout@v4`, `anthropics/claude-code-action@v1` ×2, `github/codeql-action/upload-sarif@v3`). Separate branch, since it touches workflow files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
