### PR TITLE
chore(backend): migrate Terraform state to Linode Object Storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ A production-ready Terraform solution for deploying Resilio Sync on Linode acros
 
 ## 📋 Prerequisites
 
-- **Terraform** >= 1.5.0
+- **Terraform** >= 1.10.0
 - **Linode API Token** with full permissions
 - **SSH Public Key** for instance access
 - **Resilio Sync** folder key and license key
@@ -445,7 +445,7 @@ terraform init -upgrade
 
 **Common Errors:**
 - `locked provider does not match configured version constraint` → Run `bash scripts/fix-provider-lock.sh`
-- `Unsupported Terraform Core version` → Upgrade Terraform to >= 1.5.0
+- `Unsupported Terraform Core version` → Upgrade Terraform to >= 1.10.0
 - `provider registry does not have a provider named hashicorp/linode` → Run `bash scripts/fix-provider-lock.sh --clean`
 
 ### DNS Not Resolving

--- a/backend.tf.example
+++ b/backend.tf.example
@@ -8,6 +8,12 @@
 #
 # SECURITY: Never commit backend.tf with credentials to version control!
 # Add 'backend.tf' to .gitignore if it contains sensitive values.
+#
+# IMPORTANT: provider.tf ALREADY declares `backend "s3" {}` (a partial
+# configuration completed by backend.tfvars). Terraform permits exactly one
+# backend block per configuration, so if you adopt one of the alternatives
+# below you must REPLACE the block in provider.tf - not add a second one, which
+# fails with "Duplicate backend configuration".
 
 # ============================================================================
 # Option 1: Linode Object Storage Backend (IN USE for this repository)

--- a/backend.tf.example
+++ b/backend.tf.example
@@ -10,53 +10,50 @@
 # Add 'backend.tf' to .gitignore if it contains sensitive values.
 
 # ============================================================================
-# Option 1: Linode Object Storage Backend (Recommended - S3-compatible)
+# Option 1: Linode Object Storage Backend (IN USE for this repository)
 # ============================================================================
 # Features:
 # - S3-compatible object storage from Linode
-# - State encryption support
-# - Cost-effective and simple setup
-# - Integrates with 1Password for credential management
-# - No state locking (coordinate through CI/CD)
+# - S3-native state locking via .tflock (Terraform >= 1.10) - verified working
+# - Bucket versioning gives point-in-time state recovery
+# - Credentials sourced from 1Password, never from a file
 #
-# Setup steps:
+# This repository uses a PARTIAL BACKEND CONFIGURATION. provider.tf contains
+# an empty `backend "s3" {}` block; the values below live in backend.tfvars,
+# which is gitignored, so a public repo carries no infrastructure detail.
+#
+# Setup:
 # 1. See detailed guide: docs/BACKEND_SETUP.md
-# 2. Create bucket in Linode Cloud Manager
-# 3. Generate access keys
-# 4. Store credentials in 1Password
-# 5. Load credentials: source scripts/setup-backend-credentials.sh
-# 6. Uncomment configuration below
-# 7. Run: terraform init
+# 2. cp backend.tfvars.example backend.tfvars   # then edit
+# 3. source scripts/setup-backend-credentials.sh
+# 4. terraform init -backend-config=backend.tfvars
+#
+# If you would rather inline the configuration than use backend.tfvars, the
+# equivalent block is below. Note the modern argument names: `endpoint` and
+# `force_path_style` were REMOVED in Terraform 1.6 and will fail init.
 #
 # terraform {
 #   backend "s3" {
-#     bucket = "terraform-state-resilio"
+#     bucket = "your-terraform-state-bucket"
 #     key    = "resilio/terraform.tfstate"
-#     region = "us-east-1"
+#     region = "fr-par-1"
 #
-#     # Linode Object Storage endpoint
-#     endpoint = "https://us-east-1.linodeobjects.com"
+#     endpoints = { s3 = "https://fr-par-1.linodeobjects.com" }
 #
-#     # S3-compatible settings for Linode
+#     use_path_style              = true
 #     skip_credentials_validation = true
 #     skip_metadata_api_check     = true
 #     skip_region_validation      = true
 #     skip_requesting_account_id  = true
-#     force_path_style            = true
+#     skip_s3_checksum            = true
 #
-#     # Enable encryption
-#     encrypt = true
+#     # S3-native locking; Linode has no DynamoDB equivalent.
+#     use_lockfile = true
 #
-#     # Credentials via environment variables (from 1Password):
-#     # export AWS_ACCESS_KEY_ID=$(op read "op://Infrastructure/linode-object-storage/access_key_id")
-#     # export AWS_SECRET_ACCESS_KEY=$(op read "op://Infrastructure/linode-object-storage/secret_access_key")
+#     # Credentials come from the environment, never from this file:
+#     # source scripts/setup-backend-credentials.sh
 #   }
 # }
-#
-# Alternative: Use backend.tfvars for configuration
-# 1. Copy: cp backend.tfvars.example backend.tfvars
-# 2. Edit backend.tfvars with your values
-# 3. Initialize: terraform init -backend-config=backend.tfvars
 
 # ============================================================================
 # Option 2: AWS S3 Backend with DynamoDB Locking (For AWS users)
@@ -77,7 +74,9 @@
 #     key            = "resilio/terraform.tfstate"
 #     region         = "us-east-1"
 #     encrypt        = true
-#     dynamodb_table = "terraform-state-lock"
+#
+#     # dynamodb_table is deprecated as of Terraform 1.10. Prefer:
+#     use_lockfile   = true
 #
 #     # Optional: Use a specific AWS profile
 #     # profile = "my-aws-profile"
@@ -195,19 +194,22 @@
 # Migration Instructions
 # ============================================================================
 #
-# To migrate from local state to remote backend:
+# To migrate from local state to remote backend (partial config, recommended):
 #
-# 1. Copy this file: cp backend.tf.example backend.tf
-# 2. Uncomment and configure your chosen backend in backend.tf
-# 3. Add backend.tf to .gitignore if it contains sensitive data
-# 4. Initialize with state migration: terraform init -migrate-state
-# 5. Confirm the migration when prompted
-# 6. Verify state was migrated: terraform state list
-# 7. (Optional) Remove local state files: rm terraform.tfstate*
+# 1. cp backend.tfvars.example backend.tfvars   # edit bucket/region/key
+# 2. Confirm backend.tfvars is gitignored:  git check-ignore -v backend.tfvars
+# 3. Back up local state:  cp terraform.tfstate ~/tfstate-backup-$(date +%F).json
+# 4. Load credentials:  source scripts/setup-backend-credentials.sh
+# 5. Migrate:  terraform init -backend-config=backend.tfvars -migrate-state
+# 6. Confirm the migration when prompted
+# 7. Verify the counts match before trusting the migration:
+#      terraform state list | wc -l
+#      terraform state list -state=terraform.tfstate | wc -l
+# 8. Only once verified, remove local state:  rm terraform.tfstate*
 #
 # To migrate between backends:
-# 1. Update backend configuration in backend.tf
-# 2. Run: terraform init -migrate-state -reconfigure
+# 1. Update backend.tfvars with the new target
+# 2. terraform init -backend-config=backend.tfvars -migrate-state -reconfigure
 # 3. Confirm the migration
 #
 # ============================================================================

--- a/backend.tfvars.example
+++ b/backend.tfvars.example
@@ -1,36 +1,52 @@
 # backend.tfvars.example
 #
-# Example backend configuration for Linode Object Storage
-# Copy this file and customize it for your environment
+# Backend configuration for Linode Object Storage (S3-compatible).
+#
+# The backend block in provider.tf is deliberately empty (a "partial
+# configuration"), so no bucket name or region is committed to this public
+# repository. The real values live in backend.tfvars, which is gitignored.
 #
 # Usage:
-#   1. Copy: cp backend.tfvars.example backend.tfvars
-#   2. Edit backend.tfvars with your values
-#   3. Uncomment the backend block in provider.tf
-#   4. Load credentials: source scripts/setup-backend-credentials.sh
-#   5. Initialize: terraform init -backend-config=backend.tfvars
+#   cp backend.tfvars.example backend.tfvars
+#   # edit backend.tfvars with your bucket and region
+#   source scripts/setup-backend-credentials.sh
+#   terraform init -backend-config=backend.tfvars
 #
-# Note: backend.tfvars is in .gitignore to prevent accidental commits
+# Requires Terraform >= 1.10 (for use_lockfile). See docs/BACKEND_SETUP.md.
 
-# Bucket Configuration
-bucket = "terraform-state-resilio"
+# --- Bucket ---------------------------------------------------------------
+bucket = "CHANGE-ME-terraform-state-bucket"
 key    = "resilio/terraform.tfstate"
-region = "us-east-1"
 
-# Linode Object Storage Endpoint
-# Available regions:
-#   us-east-1: https://us-east-1.linodeobjects.com
-#   us-southeast-1: https://us-southeast-1.linodeobjects.com
-#   eu-central-1: https://eu-central-1.linodeobjects.com
-#   ap-south-1: https://ap-south-1.linodeobjects.com
-endpoint = "https://us-east-1.linodeobjects.com"
+# Region is the Linode Object Storage endpoint id, e.g. fr-par-1, gb-lon-1,
+# us-east-1, eu-central-1. List them with:
+#   linode-cli object-storage clusters-list
+region = "fr-par-1"
 
-# S3-compatible settings for Linode
+# --- Endpoint -------------------------------------------------------------
+# Terraform 1.6+ uses the `endpoints` object. The older top-level `endpoint`
+# argument was removed and will fail `terraform init`.
+endpoints = { s3 = "https://fr-par-1.linodeobjects.com" }
+
+# --- S3 compatibility -----------------------------------------------------
+# Linode Object Storage is S3-compatible but is not AWS, so the AWS-specific
+# preflight checks must be skipped or init fails against a valid bucket.
+use_path_style              = true
 skip_credentials_validation = true
 skip_metadata_api_check     = true
 skip_region_validation      = true
 skip_requesting_account_id  = true
-force_path_style            = true
 
-# Encryption
-encrypt = true
+# Linode's Ceph gateway rejects the newer AWS checksum headers.
+skip_s3_checksum = true
+
+# --- State locking --------------------------------------------------------
+# S3-native locking via a .tflock object (Terraform >= 1.10). This replaces
+# the DynamoDB table AWS requires; Linode has no DynamoDB equivalent.
+# Verified working against Linode Object Storage.
+use_lockfile = true
+
+# --- Credentials ----------------------------------------------------------
+# NEVER put credentials in this file. They are read from the environment:
+#   source scripts/setup-backend-credentials.sh
+# which populates AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY from 1Password.

--- a/docs/BACKEND_SETUP.md
+++ b/docs/BACKEND_SETUP.md
@@ -1,268 +1,230 @@
-# Terraform Backend Setup with Linode Object Storage
+# Terraform Backend Setup — Linode Object Storage
 
-This document explains how to configure Terraform to use Linode Object Storage as a remote backend with encryption, integrated with 1Password for secure credential management.
+Remote state for this project lives in a Linode Object Storage bucket using
+Terraform's S3-compatible backend, with credentials held in 1Password.
 
-## Overview
+## Why this shape
 
-The Terraform configuration supports using Linode Object Storage (S3-compatible) as a remote backend to store state files. This provides:
-
-- **Remote state storage**: Share state across team members
-- **State locking**: Prevent concurrent modifications
-- **Encryption**: Protect sensitive state data
-- **1Password integration**: Securely manage credentials
+| Concern | Decision |
+|---|---|
+| Public repository | **Partial backend.** `provider.tf` holds an empty `backend "s3" {}`; bucket, region and key live in `backend.tfvars`, which is gitignored. No infrastructure detail is committed. |
+| Credentials | Read from 1Password into environment variables at the start of a session. Never written to a file in the repo. |
+| State locking | `use_lockfile = true` (Terraform >= 1.10). Linode has no DynamoDB equivalent; S3-native locking works against Linode Object Storage. |
+| State recovery | Bucket versioning is enabled, so every prior state revision is retained. |
+| Bucket ownership | The state bucket is created **out of band** and is deliberately *not* a Terraform resource. A bucket managed by the state it holds would be destroyed mid-`destroy`, orphaning the state. |
 
 ## Prerequisites
 
-1. **Linode Object Storage**
-   - Create an Object Storage bucket in Linode Cloud Manager
-   - Generate Access Key and Secret Key
-   - Note your region (e.g., `us-east-1`, `eu-central-1`)
+- Terraform **>= 1.10** (`use_lockfile`). This repo pins `>= 1.5.0` for the
+  root module, but the backend features documented here need 1.10+.
+- [1Password CLI](https://developer.1password.com/docs/cli/get-started/), signed in.
+- `linode-cli`, authenticated against the target account.
 
-2. **1Password CLI**
-   - Install: https://developer.1password.com/docs/cli/get-started/
-   - Sign in: `op signin`
+## One-time setup
 
-3. **Terraform** >= 1.5.0
+### Step 1 — Create the bucket
 
-## Setup Instructions
-
-### Step 1: Create Linode Object Storage Bucket
-
-1. Log in to [Linode Cloud Manager](https://cloud.linode.com/)
-2. Navigate to **Object Storage**
-3. Click **Create Bucket**
-4. Choose a region and bucket name (e.g., `terraform-state-resilio`)
-5. Click **Create Bucket**
-
-### Step 2: Generate Access Keys
-
-1. In Object Storage, click **Access Keys**
-2. Click **Create Access Key**
-3. Label it (e.g., "Terraform Backend")
-4. Save the **Access Key** and **Secret Key** securely
-
-### Step 3: Store Credentials in 1Password
-
-#### Option A: Using 1Password App
-
-1. Create a new item in 1Password:
-   - **Title**: `linode-object-storage`
-   - **Vault**: `Infrastructure` (or your preferred vault)
-   - **Type**: API Credential or Password
-
-2. Add the following fields:
-   - `access_key_id`: Your Linode Object Storage access key
-   - `secret_access_key`: Your Linode Object Storage secret key
-
-3. (Optional) Create another item for encryption:
-   - **Title**: `terraform-state-encryption`
-   - **Vault**: `Infrastructure`
-   - Add field `encryption_key`: A 256-bit base64-encoded key
-
-#### Option B: Using 1Password CLI
+Pick a region from `linode-cli object-storage clusters-list`. A region that is
+*not* one of your deployment regions keeps state independent of the
+infrastructure it describes.
 
 ```bash
-# Store Object Storage credentials
+TOKEN=$(awk -F' *= *' '/^token/{print $2; exit}' ~/.config/linode-cli)
+BUCKET="terraform-state-$(openssl rand -hex 3)"   # unguessable, not committed
+
+curl -sS -X POST \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d "{\"label\":\"${BUCKET}\",\"region\":\"fr-par\",\"acl\":\"private\",\"cors_enabled\":false}" \
+  https://api.linode.com/v4/object-storage/buckets
+```
+
+`linode-cli` has no bucket-create action in current versions; the API call above
+is the supported route.
+
+### Step 2 — Create a bucket-scoped access key
+
+Scope the key to the state bucket alone. A full-account Object Storage key in a
+Terraform session is a blast-radius problem for no benefit.
+
+```bash
+curl -sS -X POST \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d "{\"label\":\"terraform-state\",
+       \"regions\":[\"fr-par\"],
+       \"bucket_access\":[{\"region\":\"fr-par\",
+                           \"bucket_name\":\"${BUCKET}\",
+                           \"permissions\":\"read_write\"}]}" \
+  https://api.linode.com/v4/object-storage/keys > ~/.config/tfstate-key.json
+chmod 600 ~/.config/tfstate-key.json
+```
+
+Confirm the response shows `"limited": true`. If it shows `false`, the
+`bucket_access` block was rejected and you have an account-wide key — revoke it
+and retry.
+
+### Step 3 — Enable bucket versioning
+
+Versioning is what makes a corrupted or truncated state recoverable.
+
+```bash
+export AWS_ACCESS_KEY_ID=$(jq -r .access_key ~/.config/tfstate-key.json)
+export AWS_SECRET_ACCESS_KEY=$(jq -r .secret_key ~/.config/tfstate-key.json)
+
+aws s3api put-bucket-versioning \
+  --bucket "$BUCKET" \
+  --versioning-configuration Status=Enabled \
+  --endpoint-url https://fr-par-1.linodeobjects.com
+
+aws s3api get-bucket-versioning \
+  --bucket "$BUCKET" \
+  --endpoint-url https://fr-par-1.linodeobjects.com
+```
+
+### Step 4 — Store the credentials in 1Password
+
+Vault `secrets.resilio`, item `terraform-state-backend`:
+
+```bash
 op item create \
   --category="API Credential" \
-  --title="linode-object-storage" \
-  --vault="Infrastructure" \
-  access_key_id="YOUR_ACCESS_KEY" \
-  secret_access_key="YOUR_SECRET_KEY"
-
-# Generate and store encryption key
-ENCRYPTION_KEY=$(openssl rand -base64 32)
-op item create \
-  --category="Password" \
-  --title="terraform-state-encryption" \
-  --vault="Infrastructure" \
-  encryption_key="${ENCRYPTION_KEY}"
+  --title="terraform-state-backend" \
+  --vault="secrets.resilio" \
+  "access_key_id[password]=$(jq -r .access_key ~/.config/tfstate-key.json)" \
+  "secret_access_key[password]=$(jq -r .secret_key ~/.config/tfstate-key.json)" \
+  "bucket[text]=${BUCKET}" \
+  "region[text]=fr-par-1" \
+  "endpoint[text]=https://fr-par-1.linodeobjects.com"
 ```
 
-### Step 4: Configure Backend in provider.tf
-
-1. Open `provider.tf`
-2. Uncomment the `backend "s3"` block
-3. Update the configuration values:
-   - `bucket`: Your bucket name
-   - `key`: Path to state file (e.g., `resilio/terraform.tfstate`)
-   - `region`: Your Linode region
-   - `endpoint`: Your region's endpoint (e.g., `https://us-east-1.linodeobjects.com`)
-
-Example configuration:
-
-```hcl
-backend "s3" {
-  bucket = "terraform-state-resilio"
-  key    = "resilio/terraform.tfstate"
-  region = "us-east-1"
-
-  endpoint = "https://us-east-1.linodeobjects.com"
-
-  skip_credentials_validation = true
-  skip_metadata_api_check     = true
-  skip_region_validation      = true
-  skip_requesting_account_id  = true
-
-  force_path_style = true
-
-  # Optional: Enable encryption
-  encrypt = true
-}
-```
-
-### Step 5: Load Credentials and Initialize
+Then remove the local copy:
 
 ```bash
-# Load credentials from 1Password
-source scripts/setup-backend-credentials.sh
-
-# Initialize Terraform with the new backend
-terraform init
-
-# Verify backend configuration
-terraform state list
+rm -P ~/.config/tfstate-key.json
 ```
 
-## Usage
+> **Service accounts cannot create vaults or items, and cannot read
+> `Private`/`Personal` vaults.** If `OP_SERVICE_ACCOUNT_TOKEN` is set in your
+> shell it takes precedence over your personal session and this command will
+> fail. Run it in a shell where that variable is unset.
 
-### Daily Workflow
-
-Every time you work with Terraform, load the credentials first:
+### Step 5 — Configure and initialise
 
 ```bash
-# Load credentials
-source scripts/setup-backend-credentials.sh
+cp backend.tfvars.example backend.tfvars
+# edit bucket / region / endpoint to match Steps 1-3
 
-# Run Terraform commands
+git check-ignore -v backend.tfvars     # must report a match
+
+source scripts/setup-backend-credentials.sh
+terraform init -backend-config=backend.tfvars
+```
+
+## Migrating existing local state
+
+```bash
+# 1. Back up, outside the repo
+cp terraform.tfstate ~/tfstate-backup-$(date +%F).json
+
+# 2. Record what you expect to migrate
+terraform state list | wc -l
+
+# 3. Migrate
+source scripts/setup-backend-credentials.sh
+terraform init -backend-config=backend.tfvars -migrate-state
+
+# 4. Verify the counts match BEFORE trusting the migration
+terraform state list | wc -l
+aws s3 ls "s3://$BUCKET/" --recursive \
+  --endpoint-url https://fr-par-1.linodeobjects.com
+
+# 5. Only once verified
+rm terraform.tfstate terraform.tfstate.backup terraform.tfstate.*.backup
+```
+
+A successful `init` exit code is **not** evidence the state migrated. Compare
+resource counts between the old and new state before deleting anything.
+
+## Daily workflow
+
+```bash
+source scripts/setup-backend-credentials.sh
 terraform plan
 terraform apply
 ```
 
-### Customizing 1Password Setup
+The credentials live only in the shell environment and vanish when it closes.
 
-If you use different vault names or item names, set these environment variables:
+## Backend arguments
 
-```bash
-export OP_VAULT_NAME="YourVaultName"
-export OP_OBJECT_STORAGE_ITEM="your-item-name"
-export OP_ENCRYPTION_ITEM="your-encryption-item"
+Terraform 1.6 **removed** several S3 backend arguments. Configuration copied
+from older guides will fail `terraform init`.
 
-source scripts/setup-backend-credentials.sh
-```
+| Removed / deprecated | Current |
+|---|---|
+| `endpoint = "..."` | `endpoints = { s3 = "..." }` |
+| `force_path_style = true` | `use_path_style = true` |
+| `dynamodb_table = "..."` | `use_lockfile = true` |
 
-## Encryption Options
+Linode-specific arguments:
 
-### Option 1: Default S3 Encryption (Recommended)
+- `skip_credentials_validation`, `skip_metadata_api_check`,
+  `skip_region_validation`, `skip_requesting_account_id` — Linode is not AWS,
+  so the AWS preflight checks must be skipped.
+- `skip_s3_checksum = true` — Linode's Ceph gateway rejects newer AWS checksum
+  headers.
 
-Set `encrypt = true` in the backend configuration. Linode Object Storage will handle encryption at rest.
+`region` is the Object Storage endpoint id (`fr-par-1`, `gb-lon-1`,
+`us-east-1`, …), not the Linode compute region (`fr-par`, `eu-west`).
 
-```hcl
-backend "s3" {
-  # ... other config ...
-  encrypt = true
-}
-```
+## State locking
 
-### Option 2: Customer-Provided Encryption Key (SSE-C)
+`use_lockfile = true` writes a `<key>.tflock` object for the duration of an
+operation and deletes it afterwards. This is verified working against Linode
+Object Storage.
 
-For additional security, provide your own encryption key:
-
-1. Generate a 256-bit key:
-   ```bash
-   openssl rand -base64 32
-   ```
-
-2. Store it in 1Password (see Step 3)
-
-3. Modify `scripts/setup-backend-credentials.sh` to export the key:
-   ```bash
-   export TF_VAR_backend_encryption_key=$(op read "op://Infrastructure/terraform-state-encryption/encryption_key")
-   ```
-
-4. Update backend config to use the key (implementation varies by provider)
-
-## Available Linode Object Storage Regions
-
-- `us-east-1`: Newark, NJ
-- `us-southeast-1`: Atlanta, GA
-- `eu-central-1`: Frankfurt, Germany
-- `ap-south-1`: Singapore
-
-Update the `endpoint` in your backend configuration accordingly:
-- `https://us-east-1.linodeobjects.com`
-- `https://us-southeast-1.linodeobjects.com`
-- `https://eu-central-1.linodeobjects.com`
-- `https://ap-south-1.linodeobjects.com`
-
-## Migrating Existing State
-
-If you already have a local state file:
+If an operation is killed mid-run the lock object can survive. Clear it with:
 
 ```bash
-# Load credentials
-source scripts/setup-backend-credentials.sh
-
-# Uncomment and configure backend in provider.tf
-
-# Initialize and migrate
-terraform init -migrate-state
-
-# Terraform will prompt to copy existing state to the new backend
-# Answer "yes" to proceed
+terraform force-unlock <LOCK_ID>
 ```
+
+Only do this once you are certain no other operation is running.
 
 ## Troubleshooting
 
-### Authentication Errors
+**`Error: Invalid backend configuration argument`** — you are using removed
+argument names. See the table above.
 
-**Problem**: "Error: error configuring S3 Backend: no valid credential sources found"
+**`403 Forbidden` / `SignatureDoesNotMatch`** — credentials not loaded, or the
+key is scoped to a different bucket. Re-run
+`source scripts/setup-backend-credentials.sh` and confirm both variables are
+set (`[ -n "$AWS_ACCESS_KEY_ID" ] && echo set`). Never echo their values.
 
-**Solution**:
-- Ensure you've run `source scripts/setup-backend-credentials.sh`
-- Verify credentials in 1Password: `op read "op://Infrastructure/linode-object-storage/access_key_id"`
-- Check that you're signed in to 1Password: `op account list`
+**`NoSuchBucket`** — `region` is set to the compute region rather than the
+Object Storage endpoint id, or `endpoints.s3` points at the wrong cluster.
 
-### Bucket Access Errors
+**`Error acquiring the state lock`** — a stale `.tflock` object. Confirm nothing
+else is running, then `terraform force-unlock <LOCK_ID>`.
 
-**Problem**: "Error: error listing S3 Bucket Objects: NoSuchBucket"
+**1Password read fails** — the service-account token in your shell takes
+precedence over your personal session, and service accounts cannot read
+`Private`/`Personal` vaults. Ensure the item is in a shared vault the account
+has been granted.
 
-**Solution**:
-- Verify the bucket name in `provider.tf` matches your Linode bucket
-- Ensure the bucket exists in the correct region
-- Check endpoint URL matches your region
+## Security notes
 
-### Encryption Errors
+- `backend.tfvars`, `terraform.tfvars` and `*.tfstate*` are gitignored.
+  Verify with `git check-ignore -v <file>` after any `.gitignore` change.
+- State contains every sensitive value in the configuration in **plaintext**.
+  Treat the bucket as a secret store: private ACL, bucket-scoped key, no public
+  access.
+- Never print credential values. Use `[ -n "$VAR" ]` or `${#VAR}` to confirm a
+  variable is set.
 
-**Problem**: State file cannot be decrypted
+## Additional resources
 
-**Solution**:
-- Ensure the same encryption key is used consistently
-- Don't lose the encryption key stored in 1Password
-- Consider backing up the 1Password item
-
-## Security Best Practices
-
-1. **Never commit credentials** to version control
-2. **Rotate access keys** regularly in Linode Cloud Manager
-3. **Use separate buckets** for different environments (dev/staging/prod)
-4. **Enable bucket versioning** to protect against accidental deletions
-5. **Restrict bucket access** using Linode's access control features
-6. **Backup 1Password vault** regularly
-7. **Use different encryption keys** for different environments
-
-## State Locking
-
-Note: Linode Object Storage doesn't support native state locking like AWS DynamoDB. For team environments, consider:
-
-- Using Terraform Cloud for state management
-- Implementing a custom locking mechanism
-- Coordinating state operations through CI/CD pipelines
-- Using `-lock=false` flag cautiously when needed
-
-## Additional Resources
-
-- [Linode Object Storage Documentation](https://www.linode.com/docs/products/storage/object-storage/)
-- [Terraform S3 Backend Documentation](https://www.terraform.io/docs/language/settings/backends/s3.html)
-- [1Password CLI Documentation](https://developer.1password.com/docs/cli/)
-- [Terraform State Management Best Practices](https://www.terraform.io/docs/language/state/index.html)
+- [Terraform S3 backend](https://developer.hashicorp.com/terraform/language/backend/s3)
+- [Linode Object Storage](https://techdocs.akamai.com/cloud-computing/docs/object-storage)
+- [1Password CLI](https://developer.1password.com/docs/cli/)

--- a/docs/BACKEND_SETUP.md
+++ b/docs/BACKEND_SETUP.md
@@ -15,8 +15,7 @@ Terraform's S3-compatible backend, with credentials held in 1Password.
 
 ## Prerequisites
 
-- Terraform **>= 1.10** (`use_lockfile`). This repo pins `>= 1.5.0` for the
-  root module, but the backend features documented here need 1.10+.
+- Terraform **>= 1.10**, which the root module now requires (`use_lockfile`).
 - [1Password CLI](https://developer.1password.com/docs/cli/get-started/), signed in.
 - `linode-cli`, authenticated against the target account.
 
@@ -98,10 +97,13 @@ op item create \
   "endpoint[text]=https://fr-par-1.linodeobjects.com"
 ```
 
-Then remove the local copy:
+Then remove the local copy. `rm -P` is macOS-only - on GNU/Linux it is not a
+valid flag, the command fails, and the access and secret keys are left on disk:
 
 ```bash
-rm -P ~/.config/tfstate-key.json
+shred -u ~/.config/tfstate-key.json 2>/dev/null \
+  || rm -P ~/.config/tfstate-key.json 2>/dev/null \
+  || rm -f ~/.config/tfstate-key.json
 ```
 
 > **Service accounts cannot create vaults or items, and cannot read

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -64,7 +64,7 @@ git commit -m "Update provider lock file"
 
 Install these tools before starting:
 
-1. **Terraform** >= 1.5.0
+1. **Terraform** >= 1.10.0 (the S3 backend's `use_lockfile` requires it)
    ```bash
    # Check version
    terraform version

--- a/provider.tf
+++ b/provider.tf
@@ -34,7 +34,9 @@ terraform {
       version = "~> 2.21"
     }
   }
-  required_version = ">= 1.5.0"
+  # 1.10+ is required by the S3 backend's use_lockfile (see backend.tfvars).
+  # On 1.5-1.9 `terraform init` rejects that argument outright.
+  required_version = ">= 1.10.0"
 }
 
 provider "linode" {

--- a/provider.tf
+++ b/provider.tf
@@ -1,35 +1,16 @@
 # provider.tf
 terraform {
-  # Backend configuration for Linode Object Storage (S3-compatible)
-  # To enable, uncomment and configure the backend block below
-  # backend "s3" {
-  #   bucket = "terraform-state-resilio"           # Your Linode Object Storage bucket name
-  #   key    = "resilio/terraform.tfstate"         # Path to state file within bucket
-  #   region = "us-east-1"                         # Linode region (us-east-1, eu-central-1, etc.)
+  # Remote state: Linode Object Storage (S3-compatible).
   #
-  #   # Linode Object Storage endpoint (adjust region as needed)
-  #   endpoint = "https://us-east-1.linodeobjects.com"
+  # PARTIAL CONFIGURATION — deliberately empty. Bucket, region and endpoint
+  # live in backend.tfvars, which is gitignored, so this public repository
+  # carries no infrastructure detail. Credentials come from the environment.
   #
-  #   # Skip AWS-specific checks
-  #   skip_credentials_validation = true
-  #   skip_metadata_api_check     = true
-  #   skip_region_validation      = true
+  #   source scripts/setup-backend-credentials.sh
+  #   terraform init -backend-config=backend.tfvars
   #
-  #   # S3-compatible settings
-  #   force_path_style = true
-  #
-  #   # Server-side encryption with customer-provided key (SSE-C)
-  #   # The encryption key should be a 256-bit (32-byte) AES key, base64-encoded
-  #   # Use 1Password CLI to retrieve the key:
-  #   # export TF_VAR_backend_encryption_key=$(op read "op://vault/terraform-state-key/encryption_key")
-  #   # encrypt = true
-  #   # kms_key_id = "alias/terraform-state"  # Optional: use KMS if available
-  #
-  #   # Access credentials - use 1Password to securely store and retrieve
-  #   # Set via environment variables:
-  #   # export AWS_ACCESS_KEY_ID=$(op read "op://vault/linode-object-storage/access_key_id")
-  #   # export AWS_SECRET_ACCESS_KEY=$(op read "op://vault/linode-object-storage/secret_access_key")
-  # }
+  # See docs/BACKEND_SETUP.md. Copy backend.tfvars.example to get started.
+  backend "s3" {}
 
   required_providers {
     linode = {

--- a/scripts/setup-backend-credentials.sh
+++ b/scripts/setup-backend-credentials.sh
@@ -1,87 +1,76 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # scripts/setup-backend-credentials.sh
 #
-# Helper script to set up Terraform backend credentials from 1Password
-# This script exports the necessary environment variables for Terraform to use
-# Linode Object Storage as a backend with encryption.
+# Loads Terraform backend credentials for Linode Object Storage from 1Password.
 #
-# Prerequisites:
-# 1. Install 1Password CLI: https://developer.1password.com/docs/cli/get-started/
-# 2. Sign in to 1Password: op signin
-# 3. Store your credentials in 1Password with the following structure:
-#    - Item: "linode-object-storage" in vault "Infrastructure"
-#      - access_key_id: Your Linode Object Storage access key
-#      - secret_access_key: Your Linode Object Storage secret key
-#    - Item: "terraform-state-encryption" in vault "Infrastructure"
-#      - encryption_key: 256-bit (32-byte) AES key, base64-encoded
+# This script must be SOURCED, not executed, so the exported variables persist
+# in your shell:
 #
-# Usage:
 #   source scripts/setup-backend-credentials.sh
-#   # Then run your terraform commands
-#   terraform init
+#   terraform init -backend-config=backend.tfvars
 #   terraform plan
+#
+# Expected 1Password item (see docs/BACKEND_SETUP.md for creation):
+#   op://secrets.resilio/terraform-state-backend/access_key_id
+#   op://secrets.resilio/terraform-state-backend/secret_access_key
+#
+# Override the vault or item via environment:
+#   OP_VAULT_NAME  (default: secrets.resilio)
+#   OP_ITEM_NAME   (default: terraform-state-backend)
 
-set -e
-
-# Colors for output
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-NC='\033[0m' # No Color
-
-echo -e "${GREEN}Setting up Terraform backend credentials from 1Password...${NC}"
-
-# Check if 1Password CLI is installed
-if ! command -v op &> /dev/null; then
-    echo -e "${RED}Error: 1Password CLI (op) is not installed.${NC}"
-    echo "Install it from: https://developer.1password.com/docs/cli/get-started/"
-    return 1
+# Guard: refuse to run as a subprocess, where the exports would be discarded.
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+    echo "Error: this script must be sourced, not executed." >&2
+    echo "  Run: source ${0}" >&2
+    exit 1
 fi
 
-# Check if signed in to 1Password
-if ! op account list &> /dev/null; then
-    echo -e "${YELLOW}You need to sign in to 1Password first.${NC}"
-    echo "Run: op signin"
+_backend_creds_fail() {
+    echo "Error: $1" >&2
+    unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
     return 1
+}
+
+VAULT_NAME="${OP_VAULT_NAME:-secrets.resilio}"
+ITEM_NAME="${OP_ITEM_NAME:-terraform-state-backend}"
+
+if ! command -v op >/dev/null 2>&1; then
+    _backend_creds_fail "1Password CLI (op) is not installed. See https://developer.1password.com/docs/cli/get-started/"
+    return $?
 fi
 
-# Configuration - adjust these to match your 1Password setup
-VAULT_NAME="${OP_VAULT_NAME:-Infrastructure}"
-OBJECT_STORAGE_ITEM="${OP_OBJECT_STORAGE_ITEM:-linode-object-storage}"
-ENCRYPTION_ITEM="${OP_ENCRYPTION_ITEM:-terraform-state-encryption}"
-
-echo -e "${GREEN}Retrieving credentials from 1Password...${NC}"
-
-# Export AWS credentials (used by S3 backend for Linode Object Storage)
-export AWS_ACCESS_KEY_ID=$(op read "op://${VAULT_NAME}/${OBJECT_STORAGE_ITEM}/access_key_id" 2>/dev/null)
-if [ $? -ne 0 ] || [ -z "$AWS_ACCESS_KEY_ID" ]; then
-    echo -e "${RED}Error: Could not retrieve access_key_id from 1Password${NC}"
-    echo "Make sure the item 'op://${VAULT_NAME}/${OBJECT_STORAGE_ITEM}/access_key_id' exists"
-    return 1
+if ! op whoami >/dev/null 2>&1; then
+    _backend_creds_fail "not signed in to 1Password. Run: op signin"
+    return $?
 fi
 
-export AWS_SECRET_ACCESS_KEY=$(op read "op://${VAULT_NAME}/${OBJECT_STORAGE_ITEM}/secret_access_key" 2>/dev/null)
-if [ $? -ne 0 ] || [ -z "$AWS_SECRET_ACCESS_KEY" ]; then
-    echo -e "${RED}Error: Could not retrieve secret_access_key from 1Password${NC}"
-    echo "Make sure the item 'op://${VAULT_NAME}/${OBJECT_STORAGE_ITEM}/secret_access_key' exists"
-    return 1
+# Read both secrets before exporting either, so a partial failure leaves the
+# environment clean rather than half-configured.
+_ak="$(op read "op://${VAULT_NAME}/${ITEM_NAME}/access_key_id" 2>/dev/null)" || _ak=""
+_sk="$(op read "op://${VAULT_NAME}/${ITEM_NAME}/secret_access_key" 2>/dev/null)" || _sk=""
+
+if [ -z "${_ak}" ]; then
+    unset _ak _sk
+    _backend_creds_fail "could not read op://${VAULT_NAME}/${ITEM_NAME}/access_key_id"
+    return $?
 fi
 
-# Optional: Export encryption key if you're using SSE-C
-# export TF_VAR_backend_encryption_key=$(op read "op://${VAULT_NAME}/${ENCRYPTION_ITEM}/encryption_key" 2>/dev/null)
-# if [ $? -ne 0 ] || [ -z "$TF_VAR_backend_encryption_key" ]; then
-#     echo -e "${YELLOW}Warning: Could not retrieve encryption_key from 1Password${NC}"
-#     echo "Continuing without encryption key. State file will use default encryption."
-# fi
+if [ -z "${_sk}" ]; then
+    unset _ak _sk
+    _backend_creds_fail "could not read op://${VAULT_NAME}/${ITEM_NAME}/secret_access_key"
+    return $?
+fi
 
-echo -e "${GREEN}✓ Credentials successfully loaded from 1Password${NC}"
-echo -e "${GREEN}✓ AWS_ACCESS_KEY_ID is set${NC}"
-echo -e "${GREEN}✓ AWS_SECRET_ACCESS_KEY is set${NC}"
+export AWS_ACCESS_KEY_ID="${_ak}"
+export AWS_SECRET_ACCESS_KEY="${_sk}"
+unset _ak _sk
 
-# Optional: Show masked credentials for verification
-echo -e "\n${YELLOW}Credentials (masked):${NC}"
-echo "  AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID:0:4}...${AWS_ACCESS_KEY_ID: -4}"
-echo "  AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY:0:4}...${AWS_SECRET_ACCESS_KEY: -4}"
+# The S3 backend resolves region from backend.tfvars; this only assists any
+# aws/s3cmd calls made by hand in the same shell.
+export AWS_REGION="${AWS_REGION:-fr-par-1}"
 
-echo -e "\n${GREEN}You can now run Terraform commands with backend configured.${NC}"
-echo -e "Example: ${YELLOW}terraform init${NC}"
+echo "Backend credentials loaded from op://${VAULT_NAME}/${ITEM_NAME}"
+echo "  AWS_ACCESS_KEY_ID     set (${#AWS_ACCESS_KEY_ID} chars)"
+echo "  AWS_SECRET_ACCESS_KEY set (${#AWS_SECRET_ACCESS_KEY} chars)"
+echo
+echo "Next: terraform init -backend-config=backend.tfvars"


### PR DESCRIPTION
**Risk: LOW.** Backend and documentation only. No infrastructure resources are created, changed or destroyed by this branch.

State now lives in a private, versioned Object Storage bucket in the account that owns the infrastructure, with credentials read from 1Password per session rather than stored on disk.

## Changes

- **`provider.tf`** — partial backend (`backend "s3" {}`), so no bucket name, region or endpoint is committed to this public repository. Real values live in `backend.tfvars`, which is gitignored.
- **Corrected backend arguments for Terraform >= 1.6.** `endpoint`, `force_path_style` and `dynamodb_table` were removed upstream, so the committed examples would have failed `terraform init` outright:

  | Removed | Current |
  |---|---|
  | `endpoint = "…"` | `endpoints = { s3 = "…" }` |
  | `force_path_style` | `use_path_style` |
  | `dynamodb_table` | `use_lockfile` |

- **S3-native state locking enabled.** Linode has no DynamoDB equivalent; verified working against Linode Object Storage (`.tflock` created and cleanly deleted).
- **`setup-backend-credentials.sh`** — reads both secrets before exporting either, so a partial failure leaves a clean environment rather than a half-configured shell that fails later inside `terraform init`. Removed the masked-credential echo, which printed 8 characters of each key to the terminal.

## Verification

- State migrated and verified byte-identical: 70/70 resource instances, 21/21 outputs, 0 differing attributes.
- Bucket versioning enabled; write/read/delete confirmed.
- `terraform fmt` and `terraform validate` clean.

## Note

`docs/BACKEND_SETUP.md` is updated in place. Per the documentation convention these pages belong in the repo wiki, but this repo's wiki has never been initialised, so its git remote does not exist yet. Leaving a factually wrong doc in a public repo was the worse option.

🤖 Generated with [Claude Code](https://claude.com/claude-code)