### PR TITLE
docs(claude): correct safety claims that no longer match the code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,26 +168,64 @@ Always stage the rollout one region at a time - see 'Safe Deployment Procedures'
 
 **Before making changes that trigger instance recreation**:
 
-1. **Verify backups are current**:
+1. **Verify backups are current** - and that a real backup script is installed,
+   not the cloud-init placeholder:
    ```bash
-   ssh -J ac-user@jumpbox ac-user@resilio-instance
+   ssh -J cloud-user@<jumpbox> cloud-user@<instance>
+   ls -l /usr/local/bin/resilio-backup.sh   # placeholder ~250B, real script ~6.5KB
    sudo tail -20 /var/log/resilio-backup.log
+   sudo cat /var/lib/resilio-backup/last-success
    ```
+   `Backup script not yet provisioned` means the placeholder is installed and
+   **no backup has ever run on this host**. The placeholder exits 0, so cron
+   records success regardless.
 
 2. **Check sync status** - Ensure all data is synced across regions before proceeding
 
 3. **Apply changes one region at a time.** Never a bare `terraform apply` when
-   cloud-init has changed - that replaces all five regions together.
+   cloud-init has changed - that replaces every region in `var.regions`
+   together. Target **each** region explicitly; the list below must cover all of
+   them, or the final unrestricted apply replaces whatever was missed, all at
+   once.
    ```bash
-   # One region at a time; -target limits the blast radius
-   terraform apply -target='module.linode_instances["us-east"]'
-
-   # Wait for the region to boot AND finish re-syncing before the next
-   terraform apply -target='module.linode_instances["eu-west"]'
-
-   # Finally, apply any remaining non-instance changes
-   terraform apply
+   for r in us-east eu-west fr-par ap-northeast it-mil; do
+     terraform apply -target="module.linode_instances[\"$r\"]"
+     # then WAIT: boot, cloud-init completion, and re-sync, before the next
+   done
+   terraform apply     # reconciles firewall, DNS and anything non-instance
    ```
+
+   > **`-target` leaves the firewall stale, and the region cannot sync until you
+   > fix it.** `terraform_data.update_resilio_firewall` lives in the root module
+   > and depends on the instance IPs, so a targeted apply **excludes** it. The
+   > replaced instance comes back with a NEW IP that is absent from the shared
+   > firewall's `resilio-all-tcp/udp/icmp` rules, and its peers drop its traffic.
+   > The instance looks healthy in every API and console view while syncing with
+   > nothing.
+   >
+   > Targeting the resource does not help: it pulls in every instance as a
+   > dependency and would replace them all. Reconcile out of band after each
+   > region, which is exactly what the provisioner does anyway:
+   >
+   > ```bash
+   > # rewrite resilio-all-* with the CURRENT instance IPs
+   > curl -sS -H "Authorization: Bearer $LINODE_TOKEN" \
+   >   https://api.linode.com/v4/networking/firewalls/<resilio-fw-id>/rules
+   > # ...substitute the new IP, then PUT the full ruleset back (PUT REPLACES it,
+   > # so include inbound, inbound_policy, outbound and outbound_policy)
+   > ```
+   >
+   > Verify before moving on:
+   > ```bash
+   > curl -sS -H "Authorization: Bearer $LINODE_TOKEN" \
+   >   https://api.linode.com/v4/networking/firewalls/<id> | \
+   >   python3 -c 'import json,sys;[print(r["addresses"]["ipv4"]) for r in json.load(sys.stdin)["rules"]["inbound"] if r["label"]=="resilio-all-tcp"]'
+   > ```
+
+   > **The jumpbox firewall goes stale the same way.** `allowed_ssh_cidr` is
+   > derived from the operator's detected public IP, so when that changes nobody
+   > can SSH to any instance until `module.jumpbox_firewall` is applied. Check it
+   > before starting a rollout - you will need SSH to verify each region.
    Use `-replace=...` instead when the config has not changed but you want to
    rebuild an instance anyway.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,9 +136,17 @@ The project uses `for_each` with `toset(var.regions)` for multi-region deploymen
 - `ubuntu_advantage_token`
 - `object_storage_access_key`, `object_storage_secret_key`, `object_storage_endpoint`, `object_storage_bucket`
 
-**However**, the `ignore_changes = [metadata]` lifecycle rule in `modules/linode/main.tf` **prevents automatic instance recreation** when these variables change. This is a safety feature to protect your data and prevent unintended downtime.
+**These changes DO trigger recreation.** `metadata` is deliberately *not* in
+`ignore_changes` (commit `94df96a`, "Enable instance recreation for cloud-init
+changes"). The reasoning: silently absorbing cloud-init drift means a renewed SSL
+certificate, a rotated Object Storage key or a hardening fix can sit in Terraform
+state for months without ever reaching an instance. A visible replacement is the
+lesser evil.
 
-To apply changes to these variables, you must perform an **explicit replacement** as detailed in the 'Forcing Instance Replacement' section below.
+**The risk is therefore blast radius, not silence.** A plain `terraform apply` will
+replace **all regions at once**, and because `create_before_destroy` is not used
+(see below), every region is offline simultaneously and sync stops everywhere.
+Always stage the rollout one region at a time - see 'Safe Deployment Procedures'.
 
 **Variables that DO trigger recreation**:
 - `instance_type` changes (may recreate depending on Linode provider)
@@ -148,7 +156,7 @@ To apply changes to these variables, you must perform an **explicit replacement*
 ### Data Loss Risk Assessment
 
 **Protected (data survives instance recreation)**:
-- Volumes have `prevent_destroy = true` in `modules/volume/main.tf:14`
+- Volumes have `prevent_destroy = true` in `modules/volume/main.tf:30`
 - Volumes ignore label/region changes (`ignore_changes = [label, region]`)
 - Resilio identity and license are stored on the volume and preserved (cloud-init checks before creating)
 
@@ -168,17 +176,20 @@ To apply changes to these variables, you must perform an **explicit replacement*
 
 2. **Check sync status** - Ensure all data is synced across regions before proceeding
 
-3. **Apply changes one region at a time** using targeted applies:
+3. **Apply changes one region at a time.** Never a bare `terraform apply` when
+   cloud-init has changed - that replaces all five regions together.
    ```bash
-   # Apply to us-east first
+   # One region at a time; -target limits the blast radius
    terraform apply -target='module.linode_instances["us-east"]'
 
-   # Wait for sync to complete, then apply to other regions
+   # Wait for the region to boot AND finish re-syncing before the next
    terraform apply -target='module.linode_instances["eu-west"]'
 
-   # Finally, apply remaining changes
+   # Finally, apply any remaining non-instance changes
    terraform apply
    ```
+   Use `-replace=...` instead when the config has not changed but you want to
+   rebuild an instance anyway.
 
 4. **Never apply during active sync operations** - Wait for sync to complete
 
@@ -186,15 +197,25 @@ To apply changes to these variables, you must perform an **explicit replacement*
 
 The following safety mechanisms are in place to prevent data loss:
 
-1. **Lifecycle rules ignore metadata changes** (`modules/linode/main.tf`):
-   - `ignore_changes = [metadata]` prevents instance recreation when cloud-init variables change
-   - Configuration changes require manual intervention or explicit replacement
+1. **Volume protection is the primary data safeguard** (`modules/volume/main.tf:30`):
+   - `prevent_destroy = true` and `ignore_changes = [label, region]` mean a volume is
+     never destroyed or recreated. Instance replacement detaches and reattaches it.
+   - Note there is deliberately NO `ignore_changes = [metadata]` on the instance, so
+     cloud-init changes are visible as a replacement rather than silently dropped.
 
-2. **fs_setup does not overwrite data volume** (`modules/linode/cloud-init.tpl:33`):
-   - `overwrite: false` ensures existing data is never formatted on instance recreation
+2. **fs_setup does not overwrite data volumes** (`modules/linode/cloud-init.tpl:39`):
+   - Per-folder data volumes use `overwrite: false`, so existing filesystems are
+     never reformatted on instance recreation. `disk_setup` does the same at line 29.
+   - The OS temp partitions (`/dev/sdb1-3`, lines 34-36) DO use `overwrite: true`.
+     That is intentional - they hold `/tmp`, `/var/log` and `/var/tmp` only.
 
-3. **Create before destroy** (`modules/linode/main.tf`):
-   - `create_before_destroy = true` ensures new instance is created and can sync before old one is removed
+3. **Create before destroy is NOT used** (`modules/linode/main.tf`):
+   - Linode requires unique instance labels, so a replacement cannot be created
+     while the old instance still exists. `create_before_destroy` was deliberately
+     removed for this reason.
+   - **Consequence**: a replaced instance is destroyed FIRST, then recreated. That
+     region is offline for the duration. Replace one region at a time so the other
+     regions keep serving and can re-sync the replaced one.
 
 ### Forcing Instance Replacement
 

--- a/modules/linode/main.tf
+++ b/modules/linode/main.tf
@@ -125,6 +125,18 @@ resource "linode_instance" "resilio" {
     # so new instance can't be created while old one exists with same label
     # This means instances will be destroyed THEN created when recreated.
     # Volumes are protected with prevent_destroy = true and will survive recreation.
+
+    # user_data (metadata) is deliberately NOT in ignore_changes. Commit 94df96a
+    # removed it so that cloud-init changes DO surface as a replacement instead of
+    # being silently absorbed - a renewed SSL certificate that never reaches the
+    # instances is worse than a visible replacement.
+    #
+    # The risk this leaves is blast radius, not silence: a plain `terraform apply`
+    # replaces all regions at once and, with no create_before_destroy, every region
+    # is down together. Stage it instead, one region at a time:
+    #   terraform apply -target='module.linode_instances["us-east"]'
+    # Data volumes survive: prevent_destroy = true in modules/volume, and cloud-init
+    # uses overwrite: false for every per-folder volume.
   }
 }
 


### PR DESCRIPTION
**Risk: NONE.** Documentation and comments only; no functional change.

`CLAUDE.md` described two safety mechanisms that do not exist, and cited two line numbers pointing at the wrong lines. Anyone following it would have believed instance replacement was prevented when it is not.

## Corrections

| Claim | Reality |
|---|---|
| `ignore_changes = [metadata]` prevents instance recreation | Removed deliberately in `94df96a` ("Enable instance recreation for cloud-init changes"). Cloud-init changes **do** replace instances. |
| `create_before_destroy = true` | Removed on purpose — Linode requires unique instance labels. Replacement destroys **first**; the region is offline until it returns. |
| `modules/volume/main.tf:14` | Actually line 30 |
| `modules/linode/cloud-init.tpl:33` | Actually line 39. Line 33 is an OS disk with `overwrite: true` — the old citation pointed at the opposite of the claim it was supporting. |

Also records *why* metadata is deliberately not ignored: silently absorbing cloud-init drift means a renewed certificate or rotated key can sit in Terraform state for months without ever reaching an instance. The risk this leaves is blast radius, not silence — a bare `terraform apply` replaces all five regions at once — so the safe-deployment section now states that plainly.

## Why this matters

This was found while investigating why Terraform wanted to replace all five instances. The documented protection against exactly that scenario turned out to be fictional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)