### PR TITLE
fix(cloud-init): stop backup guard aborting all later runcmd entries

### DIFF
--- a/modules/linode/cloud-init.tpl
+++ b/modules/linode/cloud-init.tpl
@@ -743,8 +743,18 @@ runcmd:
 
   - systemctl enable --now resilio-sync
 
+
   # Configure backup based on mode (scheduled, realtime, or hybrid)
+  #
+  # SAFETY: this entire entry runs in a subshell "( ... )".
+  # cloud-init does NOT run each runcmd entry as its own script - cc_runcmd
+  # shellify()s the whole list into ONE /var/lib/cloud/instance/scripts/runcmd.
+  # A bare "exit" therefore aborts EVERY LATER ENTRY. That is exactly what used
+  # to happen: on any region with backups disabled, the guard below exited and
+  # silently skipped auditd, sshguard, AppArmor, AIDE, unattended-upgrades and
+  # the entire CIS usg fix pass. The subshell confines any exit to this block.
   - |
+    (
     CONFIG_FILE="/etc/resilio-sync/backup-config.json"
     BACKUP_ENABLED="${enable_backup}"
     ACCESS_KEY="${backup_access_key}"
@@ -797,6 +807,7 @@ runcmd:
       echo ">>> Running initial backup in background..."
       nohup /usr/local/bin/resilio-backup.sh &>/dev/null &
     fi
+    )
 
   # Load audit rules
   - [ bash, -c, "augenrules --load" ]


### PR DESCRIPTION
**Risk: SECURITY.** Changes instance provisioning. Takes effect only on instance replacement.

## The bug

cloud-init does not run each `runcmd` entry as its own script — `cc_runcmd` `shellify()`s the whole list into a single `/var/lib/cloud/instance/scripts/runcmd`. A bare `exit` therefore terminates **every later entry**.

The backup configuration entry exits `0` when backups are disabled for the region. With `backup_source_regions = ["fr-par"]`, that is **four of five regions**, and on those four everything after it never ran:

- `augenrules --load`, `auditd` enable/restart
- `sshguard` — no SSH brute-force protection, on internet-facing hosts
- AppArmor enforce
- apt-daily timers and `unattended-upgrades` — **no automatic security patching**
- `aideinit` — no file integrity baseline
- `usg fix --tailoring-file` — **the entire CIS Level 1 Server benchmark**

Those hosts have been running since January reporting success while applying none of it. Nothing was logged, because exiting `0` is indistinguishable from finishing.

## The fix

Wrap the entry in a subshell so any `exit` is confined to it. Deliberately broader than changing the single `exit 0`: it also contains any exit added to that block in future.

## Verification

```
old behaviour: >>> backup disabled
new behaviour: >>> backup disabled CIS HARDENING RAN
```

Block is valid POSIX shell (`sh -n`, `bash -n`); parens balanced.

## Note

Merge this **before** `feat/wazuh-landscape-enrolment` — that branch inserts a block at adjacent lines and will raise an add/add conflict. Resolution is "keep both".

🤖 Generated with [Claude Code](https://claude.com/claude-code)