### PR TITLE
fix(backup): repair Object Storage endpoint and fail loudly on stale backups

### DIFF
--- a/modules/object-storage/main.tf
+++ b/modules/object-storage/main.tf
@@ -42,19 +42,43 @@ resource "linode_object_storage_key" "backup" {
 
 # Local values for bucket endpoints
 locals {
+  # The API's `region` attribute is the COMPUTE region id ("us-east"), but the
+  # S3 endpoint needs the CLUSTER id ("us-east-1"). Assembling the endpoint as
+  # "${bucket.region}.linodeobjects.com" therefore produced the INVALID host
+  # "us-east.linodeobjects.com" and every backup failed to resolve.
+  #
+  # Derive it from the bucket's own hostname instead of assembling it, so it is
+  # correct whichever form the provider returns:
+  #   <label>.<cluster>.linodeobjects.com  ->  <cluster>.linodeobjects.com
+  bucket_endpoints = {
+    for region, bucket in linode_object_storage_bucket.backup :
+    region => replace(bucket.hostname, "${bucket.label}.", "")
+  }
+
   # Map of region to bucket details
-  # Object Storage region IDs already include the suffix (e.g., us-east-1)
   bucket_details = {
     for region, bucket in linode_object_storage_bucket.backup : region => {
       name     = bucket.label
-      cluster  = bucket.region # Region ID is already in correct format (e.g., us-east-1)
-      endpoint = "${bucket.region}.linodeobjects.com"
+      cluster  = split(".", local.bucket_endpoints[region])[0]
+      endpoint = local.bucket_endpoints[region]
       hostname = bucket.hostname
     }
   }
 
-  # Primary bucket (first in alphabetical order for consistency)
-  primary_region   = sort(var.backup_regions)[0]
-  primary_bucket   = local.bucket_details[local.primary_region]
+  # Primary bucket (first in alphabetical order for consistency).
+  #
+  # These must tolerate bucket_details being EMPTY. A hard index here made the
+  # configuration unable to recover from its own broken state: once the buckets
+  # were deleted out-of-band, `terraform refresh` could not complete, which is
+  # exactly the operation needed to notice the deletion and recreate them.
+  # Deadlocks like that are worse than a transiently empty value, which the
+  # consumers in main.tf already guard with `length(module.backup_storage) > 0`.
+  primary_region = length(var.backup_regions) > 0 ? sort(var.backup_regions)[0] : ""
+  primary_bucket = try(local.bucket_details[local.primary_region], {
+    name     = ""
+    cluster  = ""
+    endpoint = ""
+    hostname = ""
+  })
   primary_endpoint = local.primary_bucket.endpoint
 }

--- a/scripts/cloud-init/resilio-backup.sh.tpl
+++ b/scripts/cloud-init/resilio-backup.sh.tpl
@@ -100,7 +100,9 @@ if [ -z "$(rclone listremotes 2>/dev/null)" ]; then
   log "ERROR: no rclone remotes configured - cannot back up. Aborting."
   exit 1
 fi
-REMOTES=$(rclone listremotes 2>/dev/null | grep -E '^(r|backup-)')
+# `|| true`: with `set -e`, a non-matching grep returns 1 and would abort here,
+# before the explicit check below could log WHY nothing matched.
+REMOTES=$(rclone listremotes 2>/dev/null | grep -E '^(r|backup-)' || true)
 if [ -z "$REMOTES" ]; then
   log "ERROR: rclone has remotes but none match the expected backup naming. Aborting."
   exit 1
@@ -132,7 +134,11 @@ else
   FOLDERS="data|$BASE_MOUNT"
 fi
 
-echo "$FOLDERS" | while IFS='|' read -r FOLDER_NAME MOUNT_POINT; do
+# NOTE: fed by here-string, NOT `echo "$FOLDERS" | while`. A pipeline runs the
+# loop in a subshell, so every ERRORS increment inside it is discarded and the
+# parent sees 0 - which would write a success stamp after a totally failed run
+# and make the staleness check below report healthy. Do not reintroduce a pipe.
+while IFS='|' read -r FOLDER_NAME MOUNT_POINT; do
   [ -z "$FOLDER_NAME" ] && continue
 
   log "Backing up folder: $FOLDER_NAME from $MOUNT_POINT"
@@ -153,7 +159,7 @@ echo "$FOLDERS" | while IFS='|' read -r FOLDER_NAME MOUNT_POINT; do
       ERRORS=$((ERRORS + 1))
     fi
   done
-done
+done <<< "$FOLDERS"
 
 # Cleanup old versions (only if retention is set)
 if [ "$RETENTION_DAYS" -gt 0 ]; then

--- a/scripts/cloud-init/resilio-backup.sh.tpl
+++ b/scripts/cloud-init/resilio-backup.sh.tpl
@@ -32,6 +32,52 @@ log() {
   echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1" | tee -a "$LOG_FILE"
 }
 
+# --- Backup health -----------------------------------------------------------
+# Backups failed silently for 222 days: the configured endpoint did not resolve,
+# and nothing recorded whether a backup had ever succeeded. Both are now loud.
+STAMP_FILE="/var/lib/resilio-backup/last-success"
+STALE_AFTER_DAYS=2
+mkdir -p "$(dirname "$STAMP_FILE")"
+
+check_staleness() {
+  local last age
+  if [ ! -f "$STAMP_FILE" ]; then
+    log "WARNING: no successful backup has ever been recorded on this host"
+    return 0
+  fi
+  last=$(cat "$STAMP_FILE" 2>/dev/null || echo 0)
+  age=$(( ( $(date +%s) - last ) / 86400 ))
+  if [ "$age" -ge "$STALE_AFTER_DAYS" ]; then
+    log "ERROR: last successful backup was $age days ago (threshold $STALE_AFTER_DAYS)"
+    return 1
+  fi
+  log "Last successful backup: $age day(s) ago"
+  return 0
+}
+
+# Refuse to transfer to an endpoint that does not resolve. This is the exact
+# failure that went unnoticed: rclone was pointed at "us-east.linodeobjects.com"
+# (the compute region id) instead of "us-east-1.linodeobjects.com".
+# Uses rclone itself rather than a DNS lookup: one call exercises name
+# resolution, TLS, credentials and bucket access. A DNS-only check would have
+# caught the original bug but says nothing about a revoked or misscoped key -
+# and the key IS replaced whenever the buckets change.
+preflight_remotes() {
+  local bad=0 name ep
+  for R in $REMOTES; do
+    name=$(echo "$R" | tr -d ':')
+    ep=$(rclone config show "$name" 2>/dev/null | awk -F'= *' '/^endpoint/{print $2; exit}')
+    if rclone lsd "$R" --max-depth 1 --retries 1 --low-level-retries 1 \
+         --timeout 30s --contimeout 15s >/dev/null 2>&1; then
+      log "Preflight OK for remote '$name' ($ep)"
+    else
+      log "ERROR: remote '$name' unreachable - check DNS, endpoint, credentials or bucket ($ep)"
+      bad=$((bad + 1))
+    fi
+  done
+  return $bad
+}
+
 # Acquire lock to prevent concurrent backups
 exec 200>"$LOCK_FILE"
 if ! flock -n 200; then
@@ -47,8 +93,25 @@ log "Host: $HOSTNAME"
 log "Transfers: $TRANSFERS, Bandwidth: $${BANDWIDTH:-unlimited}"
 log "Versioning: $VERSIONING, Retention: $RETENTION_DAYS days"
 
-# Get list of rclone remotes (backup destinations)
-REMOTES=$(rclone listremotes 2>/dev/null | grep -E '^(r|backup-)' || echo "r:")
+# Get list of rclone remotes (backup destinations).
+# Previously this fell back to a bare "r:" when nothing was configured, so a
+# missing rclone config looked like a working backup. Fail instead.
+if [ -z "$(rclone listremotes 2>/dev/null)" ]; then
+  log "ERROR: no rclone remotes configured - cannot back up. Aborting."
+  exit 1
+fi
+REMOTES=$(rclone listremotes 2>/dev/null | grep -E '^(r|backup-)')
+if [ -z "$REMOTES" ]; then
+  log "ERROR: rclone has remotes but none match the expected backup naming. Aborting."
+  exit 1
+fi
+
+check_staleness || true   # reports loudly; does not block this run
+
+if ! preflight_remotes; then
+  log "ERROR: aborting - one or more backup endpoints are unreachable"
+  exit 1
+fi
 
 # Determine sync command based on versioning
 if [ "$VERSIONING" = "true" ]; then
@@ -102,6 +165,13 @@ if [ "$RETENTION_DAYS" -gt 0 ]; then
 
     rclone delete "$REMOTE$BUCKET/$HOSTNAME" --min-age "$${RETENTION_DAYS}d" >> "$LOG_FILE" 2>&1 || true
   done
+fi
+
+if [ "$ERRORS" -eq 0 ]; then
+  date +%s > "$STAMP_FILE"
+  log "Success stamp updated: $(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+else
+  log "ERROR: $ERRORS backup(s) failed - success stamp deliberately NOT updated"
 fi
 
 log "=== Backup complete (errors: $ERRORS) ==="

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -125,7 +125,7 @@ tags = ["deployment: terraform", "app: resilio", "environment: production"]
 #   ap-south-1, jp-osa-1, in-maa-1, id-cgk-1, au-mel-1 (Asia-Pacific)
 #   br-gru-1 (South America)
 # Default: ["us-east-1"]
-# backup_storage_regions = ["us-east-1", "eu-central-1"]
+# backup_storage_regions = ["us-east", "eu-central"]  # COMPUTE region ids, not cluster ids
 
 # VM regions that should run backups (which VMs push to storage)
 # Only one region needed since all VMs have same data via Resilio Sync

--- a/variables.tf
+++ b/variables.tf
@@ -180,31 +180,21 @@ variable "backup_enabled" {
 }
 
 variable "backup_storage_regions" {
-  description = "List of Linode Object Storage regions for backup destinations. Note: Object Storage uses different region IDs than compute (e.g., 'us-east-1' not 'us-east')."
+  description = "Compute region IDs in which to create backup Object Storage buckets (e.g. 'us-east', 'eu-central'). NOTE: use the COMPUTE region id, not the cluster/endpoint id. The API accepts 'us-east-1' on create but stores 'us-east', and because `region` is force-new that mismatch puts the bucket in a permanent replacement loop."
   type        = list(string)
-  default     = ["us-east-1"]
+  default     = ["us-east"]
 
   validation {
     condition = alltrue([
       for region in var.backup_storage_regions :
       contains([
-        "us-east-1",      # Newark, NJ
-        "us-southeast-1", # Atlanta, GA
-        "us-iad-1",       # Washington, DC
-        "us-ord-1",       # Chicago, IL
-        "us-sea-1",       # Seattle, WA
-        "eu-central-1",   # Frankfurt, Germany
-        "fr-par-1",       # Paris, France
-        "se-sto-1",       # Stockholm, Sweden
-        "ap-south-1",     # Singapore
-        "jp-osa-1",       # Osaka, Japan
-        "in-maa-1",       # Chennai, India
-        "id-cgk-1",       # Jakarta, Indonesia
-        "br-gru-1",       # São Paulo, Brazil
-        "au-mel-1",       # Melbourne, Australia
+        "ap-south", "au-mel", "br-gru", "de-fra-2", "es-mad", "eu-central",
+        "fr-par", "gb-lon", "id-cgk", "in-maa", "it-mil", "jp-osa", "jp-tyo-3",
+        "nl-ams", "se-sto", "sg-sin-2", "us-east", "us-iad", "us-iad-2",
+        "us-lax", "us-mia", "us-ord", "us-sea", "us-southeast",
       ], region)
     ])
-    error_message = "Invalid Object Storage region. Valid regions: us-east-1, us-southeast-1, us-iad-1, us-ord-1, us-sea-1, eu-central-1, fr-par-1, se-sto-1, ap-south-1, jp-osa-1, in-maa-1, id-cgk-1, br-gru-1, au-mel-1. Note: Object Storage regions differ from compute regions."
+    error_message = "Invalid Object Storage region. Use the COMPUTE region id (e.g. 'us-east', 'eu-central'), NOT the cluster id ('us-east-1'). List current regions with: linode-cli object-storage clusters-list"
   }
 }
 


### PR DESCRIPTION
**Risk: MEDIUM.** Changes backup behaviour and instance provisioning. Backups do not resume until instances are replaced and pick up the corrected endpoint.

## Backups have been dead for 222 days

```
ap-northeast   last backup 2026-01-24
us-east        last backup 2026-01-24
eu-west        last backup 2026-01-21
fr-par         last backup 2026-01-21
today          2026-09-03
```

3.4 TB already sitting in the legacy bucket made this invisible — size, object count and existence all looked healthy. Only `LastModified` told the truth, and nothing was checking it.

## Three independent bugs

**1. The endpoint was assembled from the wrong field.**

```hcl
endpoint = "${bucket.region}.linodeobjects.com"   # bucket.region is "us-east"
```

The API's `region` attribute is the **compute** id (`us-east`); the S3 endpoint needs the **cluster** id (`us-east-1`). rclone was pointed at `us-east.linodeobjects.com`, which does not resolve. Now derived from the bucket's own `hostname`, so it is correct whichever form the provider returns.

**2. `backup_storage_regions` required cluster ids.** The API accepts `us-east-1` on create but stores `us-east`, and `region` is force-new — so every plan wanted to replace the buckets. Now takes compute region ids; validation list rebuilt from the live API.

**3. `primary_bucket` hard-indexed a map that is empty when no buckets exist.** Once the buckets were deleted out-of-band, `terraform refresh` could not run — the very operation needed to notice the deletion. The configuration could not recover from its own broken state.

## Monitoring, since nothing was watching

- **Preflight** each rclone remote with `rclone lsd` before transferring — covers DNS, TLS, credentials and bucket access in one call, and **aborts** rather than proceeding. This is the check that would have caught bug 1 on day one.
- **Success stamp** written only when no folder failed; a stale stamp logs `ERROR: last successful backup was N days ago`.
- A missing or unmatched rclone remote now **aborts** instead of silently falling back to a bare `r:` remote, which made an absent config look like a working backup.

## Verification

- Corrected endpoints resolve; the old form does not.
- Write/read/delete succeed against both buckets with the scoped key.
- Preflight and staleness guards regression-tested under bash with stubs.
- `terraform fmt` / `validate` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)