### PR TITLE
fix(provisioning): keep remote-exec off noexec /tmp

### DIFF
--- a/modules/linode/main.tf
+++ b/modules/linode/main.tf
@@ -236,6 +236,15 @@ resource "null_resource" "provision_scripts" {
     bastion_host        = var.jumpbox_ip
     bastion_user        = var.cloud_user
     bastion_private_key = var.ssh_private_key
+
+    # The CIS Level 1 pass (usg fix, in cloud-init) remounts /tmp noexec.
+    # Terraform's remote-exec defaults to writing its bootstrap script to
+    # /tmp/terraform_NNN.sh and executing it, which then fails with
+    #   bash: /tmp/terraform_302705650.sh: Permission denied   (exit 126)
+    # Observed on us-east once hardening had completed; fr-par succeeded only
+    # because its CIS pass had not finished yet, so this is not region-specific.
+    # Put the bootstrap script somewhere exec is permitted.
+    script_path = "/home/${var.cloud_user}/terraform_provision_%RAND%.sh"
   }
 
   # Transfer resilio-folders script


### PR DESCRIPTION
**Risk: LOW.** Changes only where the provisioner writes its own bootstrap script.

## The failure

The CIS Level 1 pass (`usg fix`) remounts `/tmp` with `noexec`. Terraform's `remote-exec` provisioner defaults to writing its bootstrap script to `/tmp/terraform_NNN.sh` and executing it, so on a hardened host:

```
bash: line 1: /tmp/terraform_302705650.sh: Permission denied
Error: error executing "/tmp/terraform_302705650.sh": Process exited with status 126
```

Observed on `us-east` while provisioning the real management scripts (the fix from #51). `fr-par` succeeded in the same apply **only because its CIS pass had not finished yet** — so this is a timing difference, not a per-region one. Every hardened instance will hit it.

## Why it appeared now

Cloud-init mounts `/tmp` *without* `noexec` (`cloud-init.tpl:45`); only `/var/tmp` gets it. The `noexec` on `/tmp` arrives later, from the CIS remediation that #47 restored. Before #47 the hardening pass was silently skipped on four of five regions, so this could not surface.

Two correct changes combining into a failure: #47 made hardening actually run, #51 made the provisioner actually run, and they are incompatible at the default script path.

## Fix

Set `connection.script_path` to the cloud user's home, where exec is permitted. `%RAND%` keeps concurrent applies from colliding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)