### PR TITLE
fix(dr): stop a failed restore reporting success and starting Resilio

### DIFF
--- a/modules/linode/main.tf
+++ b/modules/linode/main.tf
@@ -248,6 +248,20 @@ resource "null_resource" "provision_scripts" {
 
   triggers = {
     instance_id = linode_instance.resilio.id
+
+    # Without this the ONLY trigger is the instance id, so editing any of the
+    # scripts below and running `terraform apply` reports "No changes" and
+    # deploys nothing - every instance keeps whatever it received when it was
+    # last CREATED. That is the same delivery gap that let a broken backup
+    # script sit undetected for 224 days, so hash the rendered sources in.
+    scripts_sha = sha256(join("", [
+      filesha256("${path.module}/../../scripts/cloud-init/resilio-folders.sh.tpl"),
+      filesha256("${path.module}/../../scripts/cloud-init/volume-auto-expand.sh.tpl"),
+      filesha256("${path.module}/../../scripts/cloud-init/resilio-backup.sh.tpl"),
+      filesha256("${path.module}/../../scripts/cloud-init/resilio-rehydrate.sh.tpl"),
+      filesha256("${path.module}/../../scripts/cloud-init/resilio-backup-watch.sh.tpl"),
+      filesha256("${path.module}/../../scripts/cloud-init/collect-diagnostics.sh"),
+    ]))
   }
 
   connection {

--- a/scripts/cloud-init/resilio-rehydrate.sh.tpl
+++ b/scripts/cloud-init/resilio-rehydrate.sh.tpl
@@ -96,8 +96,15 @@ else
   FOLDERS="data|$BASE_MOUNT"
 fi
 
-echo "$FOLDERS" | while IFS='|' read -r FOLDER_NAME MOUNT_POINT; do
+# NOTE: here-string, NOT `echo "$FOLDERS" | while`. A pipeline runs the loop in
+# a subshell, so every ERRORS increment below is discarded and the parent always
+# sees 0 - this script would then report "errors: 0", exit 0, and start Resilio
+# over folders that failed to restore. Do not reintroduce a pipe.
+SKIPPED=0
+TOTAL=0
+while IFS='|' read -r FOLDER_NAME MOUNT_POINT; do
   [ -z "$FOLDER_NAME" ] && continue
+  TOTAL=$((TOTAL + 1))
   [ -z "$MOUNT_POINT" ] && MOUNT_POINT="$BASE_MOUNT/$FOLDER_NAME"
 
   SOURCE="$REMOTE$BUCKET/$SOURCE_HOST/$FOLDER_NAME"
@@ -105,7 +112,10 @@ echo "$FOLDERS" | while IFS='|' read -r FOLDER_NAME MOUNT_POINT; do
 
   # Check if source exists
   if ! rclone lsd "$SOURCE" &>/dev/null && ! rclone ls "$SOURCE" &>/dev/null 2>&1; then
+    # Counted, not merely warned. Bad credentials or a wrong endpoint make EVERY
+    # folder "not found", which previously skipped them all and still exited 0.
     log "  WARNING: Source $SOURCE not found, skipping"
+    SKIPPED=$((SKIPPED + 1))
     continue
   fi
 
@@ -122,13 +132,31 @@ echo "$FOLDERS" | while IFS='|' read -r FOLDER_NAME MOUNT_POINT; do
     log "  ERROR: Restore failed"
     ERRORS=$((ERRORS + 1))
   fi
-done
+done <<< "$FOLDERS"
 
-# Restart Resilio Sync
+# Every source missing means the remote is wrong or unreachable, not that the
+# backups are legitimately absent. Starting Resilio over empty mount points in
+# that state risks propagating the emptiness to the healthy regions.
+if [ "$TOTAL" -gt 0 ] && [ "$SKIPPED" -eq "$TOTAL" ]; then
+  log "ERROR: no backup source was found for ANY of the $TOTAL folder(s)."
+  log "       This usually means the remote, bucket or credentials are wrong -"
+  log "       not that there is nothing to restore. Refusing to start Resilio"
+  log "       Sync, because syncing empty folders would propagate deletions."
+  exit 1
+fi
+
+if [ "$ERRORS" -gt 0 ]; then
+  log "ERROR: $ERRORS folder(s) failed to restore. Refusing to start Resilio"
+  log "       Sync: a partial restore that then syncs can delete good data on"
+  log "       the other regions. Investigate, then start it by hand."
+  exit "$ERRORS"
+fi
+
+# Restart Resilio Sync - only once every folder restored cleanly.
 if [ -z "$DRY_RUN" ]; then
   log "Starting Resilio Sync..."
   systemctl start resilio-sync
 fi
 
-log "=== Rehydration complete (errors: $ERRORS) ==="
+log "=== Rehydration complete (restored: $((TOTAL - SKIPPED)), skipped: $SKIPPED, errors: $ERRORS) ==="
 exit $ERRORS


### PR DESCRIPTION
**Risk: HIGH severity, LOW blast radius.** Two silent failures found by a systematic audit. Neither changes running infrastructure until the next apply.

## 1. A failed restore claimed success — then started Resilio over the result

`resilio-rehydrate.sh.tpl` ran its restore loop as `echo "$FOLDERS" | while ... done`. Every `ERRORS` increment happened in a pipeline subshell, so the parent always saw `0`:

```
[pipe]        ERRORS=0 -> would START Resilio   (old)
[here-string] ERRORS=2 -> REFUSE to start       (new)
```

This is the **same defect already fixed in `resilio-backup.sh.tpl`**, left unfixed in the disaster-recovery path.

Worse: a missing source was a `continue`, not an error. Bad credentials or a wrong endpoint make *every* folder "not found" — so every folder was skipped, `ERRORS` stayed `0`, the script logged `Rehydration complete (errors: 0)`, exited `0`, and **started Resilio Sync over empty mount points**. Resilio then propagates that emptiness to the healthy regions.

A tool for recovering from data loss could cause it.

**Fix:** here-string so the count survives; count skips separately; refuse to start Resilio if any folder failed *or* if every source was missing.

## 2. Editing a management script deployed nothing

`null_resource.provision_scripts` triggered **only** on `instance_id`:

```hcl
triggers = { instance_id = linode_instance.resilio.id }
```

It renders six scripts via `provisioner "file"`, but none of them are inputs to the trigger. Change `resilio-backup.sh.tpl`, run `terraform apply`, and Terraform reports **"No changes. Your infrastructure matches the configuration."** Every instance keeps whatever it received when it was last *created*.

Given the 224-day backup outage originated in exactly this delivery path, a fix to a script that never ships is worse than no fix at all.

**Fix:** hash the rendered sources into the triggers. Verified the aggregate changes when any one file changes, and returns to its original value when reverted.

## Note

`terraform apply` after merging will want to re-run `provision_scripts` on `us-east` and `fr-par` — that is correct and expected, and is how the rehydrate fix reaches them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)